### PR TITLE
fix: Restore system CA trust for Vault TLS (verascan v0.7.2 / veracmek v0.5.14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "veracode-platform"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-stream",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "rustify_derive"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07d43b2dbdbd99aaed648192098f0f413b762f0f352667153934ef3955f1793"
+checksum = "78ea7fda74240f7410d0198b603a8a2f662acc7d76b6667a49f9b162cd8d9b4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "verascan"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "backon",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -1384,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -1421,9 +1421,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
+checksum = "819b44bc7c87d9117eb522f14d46e918add69ff12713c475946b0a29363ed1c2"
 dependencies = [
  "jiff-static",
  "log",
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
+checksum = "470252db18ecc35fd766c0891b1e3ec6cbbcd62507e85276c01bf75d8e94d4a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1477,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6103dcd3815c9bd04239a6d0343dac2b7a18ee260e800d0a6e3eb5b9333504fb"
+checksum = "267fb27be492e66ab147d2ce0233d88ae465b93c3565016e73998729bf3fe60f"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1797,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a76b0c93f3dd49da2900cfb3c6b883602471a0e3e34b1578a3310ca1269d418"
+checksum = "12ecd0f3daefd4faff2e0821310c18e6e9d1fd00550bbd7e5a59d78184a071bc"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2784,9 +2784,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "veracmek"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "anyhow",
  "backon",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "verascan"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "backon",
  "chrono",
@@ -3219,9 +3219,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3232,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.63"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3246,9 +3246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3256,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3269,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -3325,9 +3325,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3821,18 +3821,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -72,15 +87,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -279,9 +303,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -382,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -392,11 +416,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -404,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -416,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -431,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -781,7 +805,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "jiff",
@@ -1001,20 +1025,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
@@ -1421,9 +1445,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819b44bc7c87d9117eb522f14d46e918add69ff12713c475946b0a29363ed1c2"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -1434,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470252db18ecc35fd766c0891b1e3ec6cbbcd62507e85276c01bf75d8e94d4a1"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267fb27be492e66ab147d2ce0233d88ae465b93c3565016e73998729bf3fe60f"
+checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1528,9 +1552,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1710,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1843,9 +1867,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -1943,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -1979,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1991,6 +2015,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2009,7 +2039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
 
@@ -2098,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ecd0f3daefd4faff2e0821310c18e6e9d1fd00550bbd7e5a59d78184a071bc"
+checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2400,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2554,12 +2584,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2663,12 +2693,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2736,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2751,9 +2781,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2995,11 +3025,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3821,18 +3851,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A comprehensive Rust client library for the Veracode security platform APIs.
 
 ### [Verascan CLI](verascan/) (`verascan`)
 
-[![Crate Version](https://img.shields.io/badge/version-0.6.4-blue.svg)](verascan/Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.7.2-blue.svg)](verascan/Cargo.toml)
 
 A powerful command-line application for security scanning and Veracode integration.
 
@@ -95,7 +95,7 @@ A powerful command-line application for security scanning and Veracode integrati
 
 ### [Veraaudit CLI](veraaudit/) (`veraaudit`)
 
-[![Crate Version](https://img.shields.io/badge/version-0.2.3-blue.svg)](veraaudit/Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.5.14-blue.svg)](veraaudit/Cargo.toml)
 
 A production-ready tool for retrieving and archiving Veracode audit logs for compliance and monitoring.
 
@@ -112,7 +112,7 @@ A production-ready tool for retrieving and archiving Veracode audit logs for com
 
 ### [Veracmek CLI](veracmek/) (`veracmek`)
 
-[![Crate Version](https://img.shields.io/badge/version-0.2.3-blue.svg)](veracmek/Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.5.14-blue.svg)](veracmek/Cargo.toml)
 
 A specialized command-line tool for managing Customer Managed Encryption Keys (CMEK) on Veracode application profiles.
 

--- a/veracmek/CHANGELOG.md
+++ b/veracmek/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to veracmek will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.14] - 2026-03-03
+
+### Fixed
+- **Vault Client System CA Trust**: Vault TLS connections now correctly trust certificates signed by CAs in the system CA bundle
+  - `create_vault_client()` now explicitly calls `.ca_certs()` on `VaultClientSettingsBuilder` with `/etc/ssl/certs/ca-certificates.crt` as a fallback when `VAULT_CACERT` is not set in the environment
+  - `VAULT_CACERT` environment variable is still respected and takes precedence over the system bundle
+  - **Modified Files**: `src/vault_client.rs`
+
+### Dependencies
+- Explicitly enabled `rustls` feature on `vaultrs` to make the TLS backend declaration visible in `Cargo.toml`
+  - **Modified Files**: `Cargo.toml`
+
 ## [0.5.13] - 2026-02-19
 
 ### Added

--- a/veracmek/Cargo.toml
+++ b/veracmek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veracmek"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2024"
 description = "CLI tool for managing Customer Managed Encryption Keys (CMEK) on Veracode application profiles"
 authors = ["Veracode API Team"]
@@ -60,6 +60,6 @@ secrecy = { version = "0.10", features = ["serde"] }
 anyhow = "1.0"
 
 # Vault client for secure credential management
-vaultrs = "0.7"
+vaultrs = { version = "0.7", features = ["rustls"] }
 backon = "1.3"
 url = "2.5"

--- a/veracmek/README.md
+++ b/veracmek/README.md
@@ -2,7 +2,7 @@
 
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-brightgreen.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Crate Version](https://img.shields.io/badge/version-0.5.13-blue.svg)](Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.5.14-blue.svg)](Cargo.toml)
 
 A command-line tool for managing Customer Managed Encryption Keys (CMEK) on Veracode application profiles. This tool enables users to encrypt application data using their own AWS KMS keys, providing enhanced security and compliance for Veracode applications.
 

--- a/veracmek/src/vault_client.rs
+++ b/veracmek/src/vault_client.rs
@@ -391,8 +391,15 @@ fn create_vault_client(config: &VaultConfig) -> Result<VaultClient, CredentialEr
         .map(|v| v != "true")
         .unwrap_or(true);
 
+    let ca_certs = std::env::var("VAULT_CACERT")
+        .map(|p| vec![p])
+        .unwrap_or_else(|_| vec!["/etc/ssl/certs/ca-certificates.crt".to_string()]);
+
     let mut settings_builder = VaultClientSettingsBuilder::default();
-    settings_builder.address(&config.addr).verify(verify_certs);
+    settings_builder
+        .address(&config.addr)
+        .verify(verify_certs)
+        .ca_certs(ca_certs);
 
     if let Some(ref namespace) = config.namespace {
         settings_builder.namespace(Some(namespace.clone()));

--- a/veracode-api/CHANGELOG.md
+++ b/veracode-api/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the veracode-platform crate will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.10] - 2026-03-18
+
+### Added
+- **`VeracodeClient::new_xml_variant()`**: New public method that creates an XML API variant of an existing client by cloning the underlying `reqwest::Client` rather than constructing a new one
+  - `reqwest::Client` is `Arc`-backed, so the clone is cheap and shares the connection pool
+  - Preserves system CA certificates loaded at initial client construction — avoids the bug where a freshly-built client inside `new_xml_client()` would re-run CA discovery with a different TLS feature set
+  - **Modified Files**: `src/client.rs`
+
+### Changed
+- **XML Client Construction in `scan_api()` and `build_api()`**: Replaced the private `new_xml_client()` constructor (which called `Self::new()` and re-built a fresh `reqwest::Client`) with `new_xml_variant()`
+  - Eliminates the hidden footgun where XML API calls silently lost system CA trust if the reqwest TLS feature graph differed between the REST and XML client instantiation paths
+  - Both methods remain infallible from the caller's perspective; the `Result` wrapper is retained for API compatibility
+  - **Modified Files**: `src/lib.rs`
+
+### Removed
+- **`new_xml_client()` private method**: Replaced by `new_xml_variant()`; the old method built a complete new `reqwest::Client` for each XML API handle, discarding pooled connections and re-loading CA certificates
+  - **Modified Files**: `src/lib.rs`
+
 ## [0.7.9] - 2026-02-26
 
 ### Added

--- a/veracode-api/Cargo.toml
+++ b/veracode-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veracode-platform"
-version = "0.7.9"
+version = "0.7.10"
 edition = "2024"
 authors = ["Fred Nollows <frednollows@gmail.com>"]
 description = "A comprehensive Rust client library for the Veracode platform (Applications, Identity, Pipeline Scan, Sandbox)"

--- a/veracode-api/src/client.rs
+++ b/veracode-api/src/client.rs
@@ -120,6 +120,21 @@ impl VeracodeClient {
         Ok(Self { config, client })
     }
 
+    /// Create an XML API variant of this client, reusing the same underlying HTTP connection pool.
+    ///
+    /// Rather than building a new `reqwest::Client` (which reloads system CA certificates and
+    /// discards pooled connections), this clones the existing client — `reqwest::Client` is
+    /// internally `Arc`-backed, so the clone is cheap and shares the connection pool.
+    #[must_use]
+    pub fn new_xml_variant(&self) -> Self {
+        let mut xml_config = self.config.clone();
+        xml_config.base_url = xml_config.xml_base_url.clone();
+        Self {
+            config: xml_config,
+            client: self.client.clone(),
+        }
+    }
+
     /// Get the base URL for API requests.
     #[must_use]
     pub fn base_url(&self) -> &str {

--- a/veracode-api/src/lib.rs
+++ b/veracode-api/src/lib.rs
@@ -445,17 +445,6 @@ pub enum VeracodeError {
 }
 
 impl VeracodeClient {
-    /// Create a specialized client for XML API operations.
-    ///
-    /// This internal method creates a client configured for the XML API
-    /// (analysiscenter.veracode.*) based on the current region settings.
-    /// Used exclusively for sandbox scan operations that require the XML API.
-    fn new_xml_client(config: VeracodeConfig) -> Result<Self, VeracodeError> {
-        let mut xml_config = config;
-        xml_config.base_url = xml_config.xml_base_url.clone();
-        Self::new(xml_config)
-    }
-
     /// Get an applications API instance.
     /// Uses REST API (api.veracode.*).
     #[must_use]
@@ -512,9 +501,7 @@ impl VeracodeClient {
     ///
     /// Returns an error if the XML client cannot be created.
     pub fn scan_api(&self) -> Result<ScanApi, VeracodeError> {
-        // Create a specialized XML client for scan operations
-        let xml_client = Self::new_xml_client(self.config().clone())?;
-        Ok(ScanApi::new(xml_client))
+        Ok(ScanApi::new(self.new_xml_variant()))
     }
 
     /// Get a build API instance.
@@ -524,9 +511,7 @@ impl VeracodeClient {
     ///
     /// Returns an error if the XML client cannot be created.
     pub fn build_api(&self) -> Result<build::BuildApi, VeracodeError> {
-        // Create a specialized XML client for build operations
-        let xml_client = Self::new_xml_client(self.config().clone())?;
-        Ok(build::BuildApi::new(xml_client))
+        Ok(build::BuildApi::new(self.new_xml_variant()))
     }
 
     /// Get a workflow helper instance.

--- a/verascan/CHANGELOG.md
+++ b/verascan/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to verascan will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Dependencies
+
+
 ## [0.7.2] - 2026-03-03
 
 ### Added
@@ -29,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 - Explicitly enabled `rustls` feature on `vaultrs` to make the TLS backend declaration visible in `Cargo.toml`
   - **Modified Files**: `Cargo.toml`
+- **`veracode-platform` → `0.7.10`**: Upstream fix for system CA trust in XML API client construction
+  - `VeracodeClient::new_xml_variant()` replaces the old `new_xml_client()` — XML handles for `scan_api()` and `build_api()` now clone the existing `reqwest::Client` instead of building a fresh one, preserving system CA certificates loaded at startup
+  - This completes the CA-trust fix started in v0.7.2: vault TLS connections were fixed then; XML scan/build API connections are fixed in this upstream release
+  - No verascan code changes required
 
 ## [0.7.1] - 2026-02-19
 

--- a/verascan/CHANGELOG.md
+++ b/verascan/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Dependencies
-
+### Fixed
+- **Cancelled Build Detection**: Verascan now exits immediately when a build is cancelled through the Veracode web interface instead of polling until timeout
+  - Veracode returns `"Unknown"` as the prescan/scan status when a build is cancelled externally; all four polling loops (`monitor_prescan_phase`, `wait_for_prescan`, `monitor_build_phase`, `wait_for_scan_completion`) previously treated this as an in-progress state and continued polling
+  - `"Unknown"` is now treated as a terminal failure status alongside `"Cancelled"` and `"Failed"`, causing an immediate error exit with the status in the message
+  - **Modified Files**: `src/assessment.rs`
 
 ## [0.7.2] - 2026-03-03
 

--- a/verascan/CHANGELOG.md
+++ b/verascan/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to verascan will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-03-03
+
+### Fixed
+- **Vault Client System CA Trust**: Restored system CA certificate trust for Vault TLS connections
+  - The reqwest 0.12 → 0.13 upgrade in v0.7.1 split the reqwest dependency graph: vaultrs retained its own reqwest 0.12.28 instance and lost the `rustls-tls-native-roots` feature it previously inherited via Cargo feature unification
+  - `create_vault_client()` now explicitly calls `.ca_certs()` on `VaultClientSettingsBuilder` with `/etc/ssl/certs/ca-certificates.crt` as a fallback when `VAULT_CACERT` is not set in the environment
+  - `VAULT_CACERT` environment variable is still respected and takes precedence over the system bundle
+  - **Modified Files**: `src/vault_client.rs`
+
+### Dependencies
+- Explicitly enabled `rustls` feature on `vaultrs` to make the TLS backend declaration visible in `Cargo.toml`
+  - **Modified Files**: `Cargo.toml`
+
 ## [0.7.1] - 2026-02-19
 
 ### Changed

--- a/verascan/CHANGELOG.md
+++ b/verascan/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.2] - 2026-03-03
 
+### Added
+- **Automatic Credential Refresh on Auth Failure**: Verascan now detects 401/403 authentication errors mid-scan and automatically refreshes credentials from HashiCorp Vault, allowing long-running scans to continue without manual intervention
+  - **Pipeline Scans** — two independent retry phases (up to 3 attempts each):
+    - *Submission phase*: on auth error a new scan is created with fresh credentials
+    - *Polling phase*: on auth error credentials are refreshed and polling resumes with the **same scan IDs** — the scan continues running on Veracode's servers, only fresh HMAC credentials are needed to query it
+  - **Assessment Scans** (sandbox & policy) — two independent retry phases (up to 3 attempts each):
+    - *Setup + upload phase*: on auth error a new scan is started with fresh credentials
+    - *Monitoring + export phase*: on auth error credentials are refreshed and monitoring resumes with the **same build ID and sandbox ID** — the scan keeps running on Veracode's servers
+  - Auth error detection covers REST API errors (`VeracodeError::Authentication`, HTTP 401/403) and XML API errors (`ScanError::Unauthorized`, `ScanError::PermissionDenied`, `PolicyError::Unauthorized`, `PolicyError::PermissionDenied`)
+  - Vault-only refresh path (`refresh_credentials_from_vault`) used for mid-scan retries — no env-var fallback, ensuring credentials are genuinely rotated
+  - **Modified Files**: `src/assessment.rs`, `src/pipeline.rs`, `src/scan.rs`, `src/vault_client.rs`, `src/lib.rs`
+
 ### Fixed
 - **Vault Client System CA Trust**: Restored system CA certificate trust for Vault TLS connections
   - The reqwest 0.12 → 0.13 upgrade in v0.7.1 split the reqwest dependency graph: vaultrs retained its own reqwest 0.12.28 instance and lost the `rustls-tls-native-roots` feature it previously inherited via Cargo feature unification

--- a/verascan/Cargo.toml
+++ b/verascan/Cargo.toml
@@ -94,7 +94,7 @@ vaultrs = { version = "0.7", features = ["rustls"] }
 backon = "1.3"
 
 [dev-dependencies]
-jsonschema = "0.44"
+jsonschema = "0.45"
 wiremock = "0.6"
 tokio-test = "0.4"
 proptest = "1.5"

--- a/verascan/Cargo.toml
+++ b/verascan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verascan"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 authors = ["Fred Nollows <frednollows@gmail.com>"]
 description = "A comprehensive Rust client application for the Veracode platform to support pipeline, sandbox and policy scan submission and reporting."
@@ -90,11 +90,11 @@ env_logger = "0.11"
 secrecy = { version = "0.10", features = ["serde"] }
 
 # Vault client for secure credential management
-vaultrs = "0.7"
+vaultrs = { version = "0.7", features = ["rustls"] }
 backon = "1.3"
 
 [dev-dependencies]
-jsonschema = "0.42"
+jsonschema = "0.44"
 wiremock = "0.6"
 tokio-test = "0.4"
 proptest = "1.5"

--- a/verascan/Cargo.toml
+++ b/verascan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verascan"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 authors = ["Fred Nollows <frednollows@gmail.com>"]
 description = "A comprehensive Rust client application for the Veracode platform to support pipeline, sandbox and policy scan submission and reporting."

--- a/verascan/README.md
+++ b/verascan/README.md
@@ -437,6 +437,14 @@ If credentials are rotated while a scan is already running, Verascan automatical
 - Up to **3 retry attempts** per phase before exiting with an error
 - Vault-only refresh path is used (no environment variable fallback) to ensure credentials are genuinely rotated
 
+## Scan Monitoring Behaviour
+
+### Cancelled Builds
+
+If a build is cancelled through the Veracode web interface while Verascan is polling, it exits immediately with an error rather than continuing to poll until timeout.
+
+Veracode returns `"Unknown"` as the prescan or scan status when a build is externally cancelled. Verascan treats this as a terminal failure alongside `"Cancelled"` and `"Failed"` statuses.
+
 ## Debugging and Troubleshooting
 
 ### Enable Debug Mode

--- a/verascan/README.md
+++ b/verascan/README.md
@@ -2,7 +2,7 @@
 
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-brightgreen.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Crate Version](https://img.shields.io/badge/version-0.7.1-blue.svg)](Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.7.2-blue.svg)](Cargo.toml)
 
 A comprehensive Rust CLI application for the Veracode platform to support pipeline, sandbox and policy scan submission and reporting.
 

--- a/verascan/README.md
+++ b/verascan/README.md
@@ -428,6 +428,15 @@ Verascan supports secure credential management via HashiCorp Vault (inherited fr
 - Fast failure on authentication errors
 - Automatic recovery from transient errors
 
+#### Mid-Scan Credential Refresh
+
+If credentials are rotated while a scan is already running, Verascan automatically detects the 401/403 error and refreshes from Vault — no manual intervention required:
+
+- **Pipeline scans**: the scan continues running on Veracode's servers; only fresh HMAC credentials are needed to resume polling with the same scan IDs
+- **Assessment scans**: the prescan/scan continues on Veracode's servers; monitoring resumes with the same build ID and sandbox ID after a credential refresh
+- Up to **3 retry attempts** per phase before exiting with an error
+- Vault-only refresh path is used (no environment variable fallback) to ensure credentials are genuinely rotated
+
 ## Debugging and Troubleshooting
 
 ### Enable Debug Mode

--- a/verascan/src/assessment.rs
+++ b/verascan/src/assessment.rs
@@ -1160,6 +1160,7 @@ impl AssessmentSubmitter {
                         return Ok(());
                     } else if prescan_results.status.contains("Failed")
                         || prescan_results.status.contains("Cancelled")
+                        || prescan_results.status.contains("Unknown")
                     {
                         return Err(AssessmentError::ScanError(format!(
                             "Prescan failed with status: {}",
@@ -1252,7 +1253,8 @@ impl AssessmentSubmitter {
                         status
                             if status.contains("Failed")
                                 || status.contains("Error")
-                                || status.contains("Cancelled") =>
+                                || status.contains("Cancelled")
+                                || status.contains("Unknown") =>
                         {
                             return Err(AssessmentError::ScanError(format!(
                                 "Scan failed with status: {status}"
@@ -1370,7 +1372,7 @@ impl AssessmentSubmitter {
                             return Ok(());
                         }
                         "Pre-Scan Failed" | "Pre-Scan Cancelled" | "Prescan Failed"
-                        | "Prescan Cancelled" => {
+                        | "Prescan Cancelled" | "Unknown" => {
                             return Err(AssessmentError::ScanError(format!(
                                 "Prescan failed with status: {}",
                                 prescan_results.status
@@ -1465,7 +1467,8 @@ impl AssessmentSubmitter {
                         status
                             if status.contains("Failed")
                                 || status.contains("Error")
-                                || status.contains("Cancelled") =>
+                                || status.contains("Cancelled")
+                                || status.contains("Unknown") =>
                         {
                             return Err(AssessmentError::ScanError(format!(
                                 "Scan failed with status: {status}"

--- a/verascan/src/assessment.rs
+++ b/verascan/src/assessment.rs
@@ -152,6 +152,8 @@ pub enum AssessmentError {
     SandboxError(String),
     PolicyError(String),
     ValidationError(ValidationError),
+    /// Authentication/authorization error (401/403) — credentials may have expired
+    AuthError(String),
 }
 
 impl std::fmt::Display for AssessmentError {
@@ -165,7 +167,32 @@ impl std::fmt::Display for AssessmentError {
             AssessmentError::SandboxError(msg) => write!(f, "Sandbox error: {msg}"),
             AssessmentError::PolicyError(msg) => write!(f, "Policy error: {msg}"),
             AssessmentError::ValidationError(e) => write!(f, "File validation error: {e}"),
+            AssessmentError::AuthError(msg) => write!(f, "Authentication error: {msg}"),
         }
+    }
+}
+
+/// Check if an `AssessmentError` is an authentication/authorization error (401/403).
+///
+/// Returns `true` when the error indicates expired or rotated credentials that
+/// can be resolved by refreshing from Vault.
+#[must_use]
+pub fn is_auth_error(error: &AssessmentError) -> bool {
+    match error {
+        AssessmentError::AuthError(_) => true,
+        AssessmentError::VeracodeError(veracode_platform::VeracodeError::Authentication(_)) => true,
+        AssessmentError::VeracodeError(veracode_platform::VeracodeError::HttpStatus {
+            status_code,
+            ..
+        }) => matches!(status_code, 401 | 403),
+        AssessmentError::VeracodeError(_)
+        | AssessmentError::NoValidFiles
+        | AssessmentError::ConfigError(_)
+        | AssessmentError::ScanError(_)
+        | AssessmentError::UploadError(_)
+        | AssessmentError::SandboxError(_)
+        | AssessmentError::PolicyError(_)
+        | AssessmentError::ValidationError(_) => false,
     }
 }
 
@@ -606,7 +633,8 @@ impl AssessmentSubmitter {
                             AssessmentError::ConfigError(msg)
                             | AssessmentError::ScanError(msg)
                             | AssessmentError::SandboxError(msg)
-                            | AssessmentError::PolicyError(msg) => msg.clone(),
+                            | AssessmentError::PolicyError(msg)
+                            | AssessmentError::AuthError(msg) => msg.clone(),
                             AssessmentError::ValidationError(err) => format!("{err}"),
                         };
                         warn!(
@@ -970,30 +998,106 @@ impl AssessmentSubmitter {
     ///
     /// # Errors
     /// Returns an error if sandbox or build creation fails, file upload fails, scan operations fail, or result export fails
-    pub async fn upload_and_scan(
+    /// Set up the scan environment and upload files, returning the scan identifiers.
+    ///
+    /// Covers steps 1–4: ensure sandbox, create/get build, upload files, start prescan.
+    /// Returns `(build_id, sandbox_id)` so the caller can resume monitoring with the
+    /// same scan even if credentials rotate before monitoring begins.
+    ///
+    /// # Errors
+    /// Returns an error if sandbox creation, build creation, upload, or prescan start fails.
+    pub async fn setup_and_start_prescan(
         &self,
         files: &[PathBuf],
         app_id: &ApplicationId,
-    ) -> Result<BuildId, AssessmentError> {
-        // Step 1: Ensure sandbox exists first (if sandbox scan) and get sandbox ID
+    ) -> Result<(BuildId, Option<SandboxId>), AssessmentError> {
         let sandbox_id = self
             .ensure_sandbox_and_get_id(app_id.for_rest_api())
             .await?;
 
-        // Step 2: Ensure build exists
         let sandbox_legacy_id = sandbox_id.as_ref().map(|s| s.for_xml_api());
         let build_id = self
             .ensure_build_exists(app_id.for_xml_api(), sandbox_legacy_id)
             .await?;
 
-        // Step 3: Upload files (now simplified)
         let _uploaded_files = self
             .upload_files(files, app_id, sandbox_id.as_ref())
             .await?;
 
-        // Step 4: Start prescan first (normal workflow)
         self.start_prescan(app_id.for_xml_api(), &build_id, sandbox_id.as_ref())
             .await?;
+
+        Ok((build_id, sandbox_id))
+    }
+
+    /// Monitor scan progress and export results for a scan already in progress.
+    ///
+    /// This is the monitoring/export phase (prescan monitoring, build monitoring, policy
+    /// evaluation, and result export). It can be called independently after
+    /// `setup_and_start_prescan`, allowing credentials to be refreshed between phases
+    /// without restarting the scan — the `build_id` and `sandbox_id` from the setup
+    /// phase are reused.
+    ///
+    /// Returns immediately without monitoring if `--no-wait` was specified in config.
+    ///
+    /// # Errors
+    /// Returns `AuthError` on 401/403 so the caller can refresh credentials and retry
+    /// with the same `build_id`/`sandbox_id`. Other errors indicate real scan failures.
+    pub async fn run_monitoring_and_export(
+        &self,
+        app_id: &ApplicationId,
+        build_id: &BuildId,
+        sandbox_id: Option<&SandboxId>,
+    ) -> Result<(), AssessmentError> {
+        if !self.config.monitor_completion {
+            info!(
+                "⏳ Prescan submitted successfully - not waiting for completion (--no-wait specified)"
+            );
+            info!("   Build ID: {}", build_id);
+            return Ok(());
+        }
+
+        if !self.is_autoscan_enabled() {
+            debug!("🔄 Autoscan disabled, will manually start scan after prescan completes");
+            self.monitor_prescan_phase(app_id.for_xml_api(), build_id, sandbox_id)
+                .await?;
+            debug!("🔄 Prescan complete, manually starting scan...");
+            self.start_scan(app_id.for_xml_api(), build_id, sandbox_id)
+                .await?;
+            self.monitor_build_phase(app_id.for_xml_api(), build_id, sandbox_id)
+                .await?;
+        } else {
+            debug!("🤖 Autoscan enabled, scan will start automatically after prescan");
+            self.monitor_scan_progress(app_id.for_xml_api(), build_id, sandbox_id)
+                .await?;
+        }
+
+        let force_buildinfo = self.config.force_buildinfo_api
+            || std::env::var("VERASCAN_FORCE_BUILDINFO_API").is_ok();
+
+        if force_buildinfo {
+            info!("🔄 XML API mode detected - adding policy evaluation phase");
+            self.monitor_policy_evaluation(app_id.for_xml_api(), sandbox_id)
+                .await?;
+        } else {
+            info!("📊 Summary report mode - policy evaluation handled during export");
+        }
+
+        self.export_scan_results(app_id, build_id, sandbox_id)
+            .await?;
+
+        Ok(())
+    }
+
+    /// # Errors
+    ///
+    /// Returns `AssessmentError` if prescan setup, upload, scan monitoring, or result export fails.
+    pub async fn upload_and_scan(
+        &self,
+        files: &[PathBuf],
+        app_id: &ApplicationId,
+    ) -> Result<BuildId, AssessmentError> {
+        let (build_id, sandbox_id) = self.setup_and_start_prescan(files, app_id).await?;
 
         // Check if we should exit early (--no-wait specified)
         if !self.config.monitor_completion {
@@ -1004,54 +1108,7 @@ impl AssessmentSubmitter {
             return Ok(build_id);
         }
 
-        // Check if we need to manually start scan (only if autoscan is disabled)
-        if !self.is_autoscan_enabled() {
-            debug!("🔄 Autoscan disabled, will manually start scan after prescan completes");
-        } else {
-            debug!("🤖 Autoscan enabled, scan will start automatically after prescan");
-        }
-
-        // Use two-phase monitoring approach matching Java implementation
-        // This handles both prescan completion and scan completion automatically
-        if !self.is_autoscan_enabled() {
-            // For manual scan workflows, monitor prescan first, then start scan, then monitor build
-            self.monitor_prescan_phase(app_id.for_xml_api(), &build_id, sandbox_id.as_ref())
-                .await?;
-
-            debug!("🔄 Prescan complete, manually starting scan...");
-            self.start_scan(app_id.for_xml_api(), &build_id, sandbox_id.as_ref())
-                .await?;
-
-            // Monitor build phase (scan completion)
-            self.monitor_build_phase(app_id.for_xml_api(), &build_id, sandbox_id.as_ref())
-                .await?;
-        } else {
-            // For autoscan workflows, use unified two-phase monitoring
-            self.monitor_scan_progress(app_id.for_xml_api(), &build_id, sandbox_id.as_ref())
-                .await?;
-        }
-
-        // Phase 3: Policy evaluation monitoring (XML API only)
-        // Check if we will be using the XML API for policy status
-        let force_buildinfo = self.config.force_buildinfo_api
-            || std::env::var("VERASCAN_FORCE_BUILDINFO_API").is_ok();
-
-        if force_buildinfo {
-            // We know we'll use XML API, so wait for policy evaluation to complete
-            {
-                info!("🔄 XML API mode detected - adding policy evaluation phase");
-            }
-            self.monitor_policy_evaluation(app_id.for_xml_api(), sandbox_id.as_ref())
-                .await?;
-        } else {
-            // Summary report API will be tried first with built-in retry logic
-            {
-                info!("📊 Summary report mode - policy evaluation handled during export");
-            }
-        }
-
-        // Export results to file
-        self.export_scan_results(app_id, &build_id, sandbox_id.as_ref())
+        self.run_monitoring_and_export(app_id, &build_id, sandbox_id.as_ref())
             .await?;
 
         Ok(build_id)
@@ -1330,9 +1387,16 @@ impl AssessmentSubmitter {
                     }
                 }
                 Err(e) => {
-                    {
-                        info!("⚠️  Error getting prescan status: {e}, retrying...");
+                    if matches!(
+                        e,
+                        veracode_platform::scan::ScanError::Unauthorized
+                            | veracode_platform::scan::ScanError::PermissionDenied
+                    ) {
+                        return Err(AssessmentError::AuthError(format!(
+                            "Authentication error during prescan monitoring: {e}"
+                        )));
                     }
+                    info!("⚠️  Error getting prescan status: {e}, retrying...");
                     tokio::time::sleep(tokio::time::Duration::from_secs(poll_interval.into()))
                         .await;
                 }
@@ -1423,9 +1487,16 @@ impl AssessmentSubmitter {
                     }
                 }
                 Err(e) => {
-                    {
-                        info!("⚠️  Error getting build status: {e}, retrying...");
+                    if matches!(
+                        e,
+                        veracode_platform::scan::ScanError::Unauthorized
+                            | veracode_platform::scan::ScanError::PermissionDenied
+                    ) {
+                        return Err(AssessmentError::AuthError(format!(
+                            "Authentication error during build monitoring: {e}"
+                        )));
                     }
+                    info!("⚠️  Error getting build status: {e}, retrying...");
                     tokio::time::sleep(tokio::time::Duration::from_secs(poll_interval.into()))
                         .await;
                 }
@@ -1480,9 +1551,20 @@ impl AssessmentSubmitter {
                 }
                 Ok(())
             }
-            Err(e) => Err(AssessmentError::ScanError(format!(
-                "Policy evaluation phase failed: {e}"
-            ))),
+            Err(e) => {
+                if matches!(
+                    e,
+                    veracode_platform::policy::PolicyError::Unauthorized
+                        | veracode_platform::policy::PolicyError::PermissionDenied
+                ) {
+                    return Err(AssessmentError::AuthError(format!(
+                        "Authentication error during policy evaluation: {e}"
+                    )));
+                }
+                Err(AssessmentError::ScanError(format!(
+                    "Policy evaluation phase failed: {e}"
+                )))
+            }
         }
     }
 

--- a/verascan/src/lib.rs
+++ b/verascan/src/lib.rs
@@ -65,7 +65,7 @@ pub use policy::execute_policy_download;
 pub use scan::{execute_assessment_scan, execute_pipeline_scan};
 pub use vault_client::{
     VaultCredentialClient, load_credentials_and_proxy_from_vault, load_vault_config_from_env,
-    load_veracode_credentials_with_vault,
+    load_veracode_credentials_with_vault, refresh_credentials_from_vault,
 };
 
 use log::error;

--- a/verascan/src/pipeline.rs
+++ b/verascan/src/pipeline.rs
@@ -51,6 +51,35 @@ impl From<ValidationError> for PipelineError {
     }
 }
 
+/// Check if a `PipelineError` is an authentication/authorization error (401/403)
+///
+/// Returns `true` if the error indicates expired or invalid credentials, which
+/// can be resolved by refreshing credentials from Vault.
+#[must_use]
+pub fn is_auth_error(error: &PipelineError) -> bool {
+    use veracode_platform::pipeline::PipelineError as PlatformPipelineError;
+    match error {
+        PipelineError::VeracodeError(veracode_platform::VeracodeError::Authentication(_)) => true,
+        PipelineError::VeracodeError(veracode_platform::VeracodeError::HttpStatus {
+            status_code,
+            ..
+        }) => matches!(status_code, 401 | 403),
+        PipelineError::PlatformPipelineError(PlatformPipelineError::PermissionDenied(_)) => true,
+        PipelineError::PlatformPipelineError(PlatformPipelineError::ApiError(
+            veracode_platform::VeracodeError::Authentication(_),
+        )) => true,
+        PipelineError::PlatformPipelineError(PlatformPipelineError::ApiError(
+            veracode_platform::VeracodeError::HttpStatus { status_code, .. },
+        )) => matches!(status_code, 401 | 403),
+        PipelineError::VeracodeError(_)
+        | PipelineError::PlatformPipelineError(_)
+        | PipelineError::NoValidFiles
+        | PipelineError::ConfigError(_)
+        | PipelineError::ScanError(_)
+        | PipelineError::ValidationError(_) => false,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PipelineScanConfig {
     pub project_name: String,
@@ -626,6 +655,98 @@ impl PipelineSubmitter {
         Ok(sorted_results)
     }
 
+    /// Poll for results of one or more scans by their scan IDs.
+    ///
+    /// Polls all scans concurrently (bounded by `config.threads`). Auth errors
+    /// (401/403) are surfaced immediately so the caller can refresh credentials
+    /// and retry with the same scan IDs. Other transient errors are retried
+    /// within `wait_for_scan_completion`.
+    ///
+    /// # Errors
+    /// Returns an auth error if credentials have expired, or a scan error if a
+    /// scan failed or timed out.
+    pub async fn poll_for_scan_results(
+        &self,
+        scan_ids: &[String],
+    ) -> Result<Vec<veracode_platform::pipeline::ScanResults>, PipelineError> {
+        if scan_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let timeout_minutes = self.config.timeout.unwrap_or(60);
+        debug!(
+            "⏳ Polling {} scan(s) for results (timeout: {} minutes each)...",
+            scan_ids.len(),
+            timeout_minutes
+        );
+
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(self.config.threads));
+        let mut join_set: JoinSet<
+            Result<(usize, veracode_platform::pipeline::ScanResults), (usize, PipelineError)>,
+        > = JoinSet::new();
+        let submitter_arc = Arc::new(self.clone());
+
+        for (index, scan_id) in scan_ids.iter().enumerate() {
+            let scan_id_ref = scan_id.clone();
+            let semaphore_ref = Arc::clone(&semaphore);
+            let submitter_ref = Arc::clone(&submitter_arc);
+
+            join_set.spawn(async move {
+                let _permit = match semaphore_ref.acquire().await {
+                    Ok(p) => p,
+                    Err(_) => {
+                        return Err((
+                            index,
+                            PipelineError::ScanError(
+                                "Failed to acquire semaphore permit".to_string(),
+                            ),
+                        ));
+                    }
+                };
+                submitter_ref
+                    .wait_for_scan_completion(&scan_id_ref)
+                    .await
+                    .map(|r| (index, r))
+                    .map_err(|e| (index, e))
+            });
+        }
+
+        let mut scan_results: Vec<(usize, veracode_platform::pipeline::ScanResults)> = Vec::new();
+        let mut first_auth_error: Option<PipelineError> = None;
+        let mut first_other_error: Option<PipelineError> = None;
+
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Ok((index, results))) => scan_results.push((index, results)),
+                Ok(Err((_, e))) => {
+                    if is_auth_error(&e) {
+                        if first_auth_error.is_none() {
+                            first_auth_error = Some(e);
+                        }
+                        join_set.abort_all();
+                    } else if first_other_error.is_none() {
+                        first_other_error = Some(e);
+                    }
+                }
+                Err(join_error) => {
+                    // Task was aborted (due to auth error detected on another task) or panicked
+                    debug!("Poll task ended: {join_error}");
+                }
+            }
+        }
+
+        // Auth errors take priority — caller can refresh credentials and retry all scan IDs
+        if let Some(e) = first_auth_error {
+            return Err(e);
+        }
+        if let Some(e) = first_other_error {
+            return Err(e);
+        }
+
+        scan_results.sort_by_key(|(idx, _)| *idx);
+        Ok(scan_results.into_iter().map(|(_, r)| r).collect())
+    }
+
     /// Wait for a specific scan to complete
     async fn wait_for_scan_completion(
         &self,
@@ -670,7 +791,11 @@ impl PipelineSubmitter {
                     }
                 }
                 Err(e) => {
-                    debug!("⚠️  Error getting scan status for {scan_id}: {e}, retrying...");
+                    let wrapped = PipelineError::PlatformPipelineError(e);
+                    if is_auth_error(&wrapped) {
+                        return Err(wrapped);
+                    }
+                    debug!("⚠️  Error getting scan status for {scan_id}: {wrapped}, retrying...");
                     tokio::time::sleep(tokio::time::Duration::from_secs(poll_interval.into()))
                         .await;
                 }

--- a/verascan/src/scan.rs
+++ b/verascan/src/scan.rs
@@ -282,13 +282,19 @@ pub fn execute_pipeline_scan(
         let region = parse_region(&args.region)?;
         let pipeline_config = create_pipeline_config(args, region);
 
-        let submitter =
-            PipelineSubmitter::new(veracode_config.clone(), pipeline_config).map_err(|e| {
+        let submitter = PipelineSubmitter::new(veracode_config.clone(), pipeline_config.clone())
+            .map_err(|e| {
                 error!("❌ Failed to create pipeline submitter: {e}");
                 1
             })?;
 
-        execute_scan_with_runtime(submitter, matched_files, args, veracode_config)
+        execute_scan_with_runtime(
+            submitter,
+            matched_files,
+            args,
+            veracode_config,
+            pipeline_config,
+        )
     } else {
         error!("❌ execute_pipeline_scan called with non-pipeline command");
         Err(1)
@@ -562,6 +568,7 @@ fn execute_scan_with_runtime(
     matched_files: &[PathBuf],
     args: &Args,
     veracode_config: &VeracodeConfig,
+    pipeline_config: PipelineScanConfig,
 ) -> Result<(), i32> {
     let rt = tokio::runtime::Runtime::new().map_err(|e| {
         error!("❌ Failed to create async runtime: {e}");
@@ -583,94 +590,262 @@ fn execute_scan_with_runtime(
             }
         }
 
-        if matched_files.len() == 1 {
-            execute_single_scan(&submitter, matched_files, args, veracode_config).await
-        } else {
-            execute_concurrent_scans(&submitter, matched_files, args, veracode_config).await
-        }
+        run_pipeline_scan_with_auth_retry(
+            submitter,
+            matched_files,
+            args,
+            veracode_config.clone(),
+            &pipeline_config,
+        )
+        .await
     })
 }
 
-async fn execute_single_scan(
-    submitter: &PipelineSubmitter,
-    matched_files: &[PathBuf],
-    args: &Args,
-    veracode_config: &VeracodeConfig,
-) -> Result<(), i32> {
-    match submitter.submit_and_wait(matched_files).await {
-        Ok(results) => {
-            submitter.display_results_summary(&results);
-
-            let results_vec = vec![results];
-
-            // Handle findings aggregation and export
-            handle_findings_export(&results_vec, matched_files, args, veracode_config).await;
-
-            // Handle GitLab issues creation if requested (independent of export)
-            if let Commands::Pipeline {
-                create_gitlab_issues,
-                ..
-            } = &args.command
-                && *create_gitlab_issues
-            {
-                handle_gitlab_issues_creation_from_results_async(
-                    &results_vec,
-                    matched_files,
-                    args,
-                    veracode_config,
-                )
-                .await;
+/// Refresh credentials from Vault and rebuild the `PipelineSubmitter`.
+/// Returns `None` and logs errors on failure.
+async fn try_refresh_submitter(
+    region: &str,
+    pipeline_config: &PipelineScanConfig,
+) -> Option<(PipelineSubmitter, VeracodeConfig)> {
+    match crate::vault_client::refresh_credentials_from_vault().await {
+        Ok((creds, proxy_url, proxy_user, proxy_pass)) => {
+            match crate::create_veracode_config_with_proxy(
+                creds, region, proxy_url, proxy_user, proxy_pass,
+            ) {
+                Ok(new_config) => {
+                    match PipelineSubmitter::new(new_config.clone(), pipeline_config.clone()) {
+                        Ok(new_submitter) => Some((new_submitter, new_config)),
+                        Err(e) => {
+                            error!("❌ Failed to create submitter with refreshed credentials: {e}");
+                            None
+                        }
+                    }
+                }
+                Err(_) => {
+                    error!("❌ Failed to create Veracode config with refreshed credentials");
+                    None
+                }
             }
-
-            Ok(())
         }
         Err(e) => {
-            error!("❌ Pipeline scan failed: {e}");
-            Err(1)
+            warn!("Failed to refresh credentials from Vault: {e}");
+            error!("❌ Cannot retry: Vault credential refresh failed");
+            None
         }
     }
 }
 
-async fn execute_concurrent_scans(
-    submitter: &PipelineSubmitter,
+/// Run a pipeline scan with automatic credential refresh on 401/403 errors.
+///
+/// The operation is split into two independent retry phases:
+///
+/// - **Submission** (`submit_files` / `submit_files_concurrent`): on auth error a new scan
+///   is created with fresh credentials (up to `MAX_ATTEMPTS` total attempts).
+/// - **Polling** (`poll_for_scan_results`): on auth error the credentials are refreshed
+///   and polling resumes with the **same scan IDs** — the scan keeps running on Veracode's
+///   servers and only fresh HMAC credentials are needed to query it (up to `MAX_ATTEMPTS`
+///   total attempts).
+async fn run_pipeline_scan_with_auth_retry(
+    initial_submitter: PipelineSubmitter,
     matched_files: &[PathBuf],
     args: &Args,
-    veracode_config: &VeracodeConfig,
+    initial_config: VeracodeConfig,
+    pipeline_config: &PipelineScanConfig,
 ) -> Result<(), i32> {
-    match submitter
-        .submit_files_concurrent_and_wait(matched_files)
-        .await
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut current_submitter = initial_submitter;
+    let mut current_config = initial_config;
+
+    // ── Phase 1: Submit ──────────────────────────────────────────────────────
+    // Submit the file(s) and obtain scan IDs. On 401/403 the submission is
+    // retried from scratch with refreshed credentials (a new scan is created).
+    let scan_ids: Vec<String> = {
+        let mut attempt = 0u32;
+        loop {
+            attempt = attempt.saturating_add(1);
+            let result = if matched_files.len() == 1 {
+                current_submitter
+                    .submit_files(matched_files)
+                    .await
+                    .map(|id| vec![id])
+            } else {
+                current_submitter
+                    .submit_files_concurrent(matched_files)
+                    .await
+            };
+            match result {
+                Ok(ids) => break ids,
+                Err(ref e) if crate::pipeline::is_auth_error(e) && attempt < MAX_ATTEMPTS => {
+                    warn!(
+                        "⚠️  Authentication error during scan submission \
+                         (attempt {attempt}/{MAX_ATTEMPTS}), refreshing credentials from Vault..."
+                    );
+                    match try_refresh_submitter(&args.region, pipeline_config).await {
+                        Some((new_submitter, new_config)) => {
+                            info!(
+                                "✅ Credentials refreshed, retrying submission \
+                                 (attempt {}/{MAX_ATTEMPTS})...",
+                                attempt.saturating_add(1)
+                            );
+                            current_submitter = new_submitter;
+                            current_config = new_config;
+                        }
+                        None => return Err(1),
+                    }
+                }
+                Err(e) => {
+                    error!("❌ Pipeline scan submission failed: {e}");
+                    return Err(1);
+                }
+            }
+        }
+    };
+
+    // ── Phase 2: Poll ────────────────────────────────────────────────────────
+    // Poll for results using the scan IDs already obtained. On 401/403 the
+    // credentials are refreshed and polling resumes with the same scan IDs —
+    // the scan is still running on Veracode's servers.
+    let results_vec: Vec<veracode_platform::pipeline::ScanResults> = {
+        let mut attempt = 0u32;
+        loop {
+            attempt = attempt.saturating_add(1);
+            match current_submitter.poll_for_scan_results(&scan_ids).await {
+                Ok(results) => break results,
+                Err(ref e) if crate::pipeline::is_auth_error(e) && attempt < MAX_ATTEMPTS => {
+                    warn!(
+                        "⚠️  Authentication error during scan polling \
+                         (attempt {attempt}/{MAX_ATTEMPTS}), refreshing credentials from Vault..."
+                    );
+                    match try_refresh_submitter(&args.region, pipeline_config).await {
+                        Some((new_submitter, new_config)) => {
+                            info!(
+                                "✅ Credentials refreshed, resuming poll with same scan IDs \
+                                 (attempt {}/{MAX_ATTEMPTS})...",
+                                attempt.saturating_add(1)
+                            );
+                            current_submitter = new_submitter;
+                            current_config = new_config;
+                        }
+                        None => return Err(1),
+                    }
+                }
+                Err(e) => {
+                    error!("❌ Pipeline scan polling failed: {e}");
+                    return Err(1);
+                }
+            }
+        }
+    };
+
+    // ── Post-processing ──────────────────────────────────────────────────────
+    if matched_files.len() == 1 {
+        if let Some(result) = results_vec.first() {
+            current_submitter.display_results_summary(result);
+        }
+    } else {
+        display_concurrent_results(&results_vec, &current_submitter);
+    }
+
+    handle_findings_export(&results_vec, matched_files, args, &current_config).await;
+
+    if let Commands::Pipeline {
+        create_gitlab_issues,
+        ..
+    } = &args.command
+        && *create_gitlab_issues
     {
-        Ok(results_vec) => {
-            display_concurrent_results(&results_vec, submitter);
-
-            // Handle findings aggregation and export
-            handle_findings_export(&results_vec, matched_files, args, veracode_config).await;
-
-            // Handle GitLab issues creation if requested (independent of export)
-            if let Commands::Pipeline {
-                create_gitlab_issues,
-                ..
-            } = &args.command
-                && *create_gitlab_issues
-            {
-                handle_gitlab_issues_creation_from_results_async(
-                    &results_vec,
-                    matched_files,
-                    args,
-                    veracode_config,
-                )
-                .await;
-            }
-
-            Ok(())
-        }
-        Err(e) => {
-            error!("❌ Concurrent pipeline scans failed: {e}");
-            Err(1)
-        }
+        handle_gitlab_issues_creation_from_results_async(
+            &results_vec,
+            matched_files,
+            args,
+            &current_config,
+        )
+        .await;
     }
+
+    Ok(())
 }
+
+//async fn execute_single_scan(
+//    submitter: &PipelineSubmitter,
+//    matched_files: &[PathBuf],
+//    args: &Args,
+//    veracode_config: &VeracodeConfig,
+//) -> Result<(), i32> {
+//    match submitter.submit_and_wait(matched_files).await {
+//        Ok(results) => {
+//            submitter.display_results_summary(&results);
+//
+//            let results_vec = vec![results];
+//
+//            // Handle findings aggregation and export
+//            handle_findings_export(&results_vec, matched_files, args, veracode_config).await;
+//
+//            // Handle GitLab issues creation if requested (independent of export)
+//            if let Commands::Pipeline {
+//                create_gitlab_issues,
+//                ..
+//            } = &args.command
+//                && *create_gitlab_issues
+//            {
+//                handle_gitlab_issues_creation_from_results_async(
+//                    &results_vec,
+//                    matched_files,
+//                    args,
+//                    veracode_config,
+//                )
+//                .await;
+//            }
+//
+//            Ok(())
+//        }
+//        Err(e) => {
+//            error!("❌ Pipeline scan failed: {e}");
+//            Err(1)
+//        }
+//    }
+//}
+//
+//async fn execute_concurrent_scans(
+//    submitter: &PipelineSubmitter,
+//    matched_files: &[PathBuf],
+//    args: &Args,
+//    veracode_config: &VeracodeConfig,
+//) -> Result<(), i32> {
+//    match submitter
+//        .submit_files_concurrent_and_wait(matched_files)
+//        .await
+//    {
+//        Ok(results_vec) => {
+//            display_concurrent_results(&results_vec, submitter);
+//
+//            // Handle findings aggregation and export
+//            handle_findings_export(&results_vec, matched_files, args, veracode_config).await;
+//
+//            // Handle GitLab issues creation if requested (independent of export)
+//            if let Commands::Pipeline {
+//                create_gitlab_issues,
+//                ..
+//            } = &args.command
+//                && *create_gitlab_issues
+//            {
+//                handle_gitlab_issues_creation_from_results_async(
+//                    &results_vec,
+//                    matched_files,
+//                    args,
+//                    veracode_config,
+//                )
+//                .await;
+//            }
+//
+//            Ok(())
+//        }
+//        Err(e) => {
+//            error!("❌ Concurrent pipeline scans failed: {e}");
+//            Err(1)
+//        }
+//    }
+//}
 
 fn display_concurrent_results(
     results_vec: &[veracode_platform::pipeline::ScanResults],
@@ -1710,6 +1885,42 @@ fn execute_assessment_scan_with_runtime(
     )
 }
 
+/// Refresh credentials from Vault and rebuild the `AssessmentSubmitter`.
+/// Returns `None` and logs errors on failure.
+async fn try_refresh_assessment_submitter(
+    region: &str,
+    assessment_config: &AssessmentScanConfig,
+) -> Option<(AssessmentSubmitter, VeracodeConfig)> {
+    match crate::vault_client::refresh_credentials_from_vault().await {
+        Ok((creds, proxy_url, proxy_user, proxy_pass)) => {
+            match crate::create_veracode_config_with_proxy(
+                creds, region, proxy_url, proxy_user, proxy_pass,
+            ) {
+                Ok(new_config) => {
+                    match AssessmentSubmitter::new(new_config.clone(), assessment_config.clone()) {
+                        Ok(new_submitter) => Some((new_submitter, new_config)),
+                        Err(e) => {
+                            error!(
+                                "❌ Failed to create assessment submitter with refreshed credentials: {e}"
+                            );
+                            None
+                        }
+                    }
+                }
+                Err(_) => {
+                    error!("❌ Failed to create Veracode config with refreshed credentials");
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            warn!("Failed to refresh credentials from Vault: {e}");
+            error!("❌ Cannot retry: Vault credential refresh failed");
+            None
+        }
+    }
+}
+
 /// Async execution of assessment scan
 async fn execute_assessment_scan_async(
     submitter: AssessmentSubmitter,
@@ -1754,71 +1965,173 @@ async fn execute_assessment_scan_async(
             debug!("   Repository URL: Not provided and auto-detection failed");
         }
 
-        let app_id = match submitter
-            .client
-            .create_application_if_not_exists(
-                app_profile_name,
-                crate::cli::parse_business_criticality(bus_cri),
-                Some("Application created for assessment scanning".to_string()),
-                team_names,
-                resolved_repo_url,
-                cmek.clone(),
-            )
-            .await
-        {
-            Ok(app) => {
-                debug!(
-                    "✅ Application ready: {} (ID: {}, GUID: {})",
-                    app.profile
-                        .as_ref()
-                        .map(|p| p.name.as_str())
-                        .unwrap_or("Unknown"),
-                    app.id,
-                    app.guid
-                );
-                if let Some(profile) = &app.profile
-                    && let Some(teams) = &profile.teams
-                    && !teams.is_empty()
+        const MAX_ATTEMPTS: u32 = 3;
+        let mut current_submitter = submitter;
+
+        // ── Phase 1: Setup + upload + start prescan ──────────────────────────
+        // On 401/403, refresh credentials and retry from scratch (up to MAX_ATTEMPTS).
+        let (app_id, build_id, sandbox_id) = {
+            let mut attempt = 0u32;
+            loop {
+                attempt = attempt.saturating_add(1);
+
+                let app = match current_submitter
+                    .client
+                    .create_application_if_not_exists(
+                        app_profile_name,
+                        crate::cli::parse_business_criticality(bus_cri),
+                        Some("Application created for assessment scanning".to_string()),
+                        team_names.clone(),
+                        resolved_repo_url.clone(),
+                        cmek.clone(),
+                    )
+                    .await
                 {
-                    let team_names: Vec<String> = teams
-                        .iter()
-                        .filter_map(|t| t.team_name.as_ref())
-                        .cloned()
-                        .collect();
-                    debug!("   Associated teams: {}", team_names.join(", "));
+                    Ok(app) => {
+                        debug!(
+                            "✅ Application ready: {} (ID: {}, GUID: {})",
+                            app.profile
+                                .as_ref()
+                                .map(|p| p.name.as_str())
+                                .unwrap_or("Unknown"),
+                            app.id,
+                            app.guid
+                        );
+                        if let Some(profile) = &app.profile
+                            && let Some(teams) = &profile.teams
+                            && !teams.is_empty()
+                        {
+                            let team_names: Vec<String> = teams
+                                .iter()
+                                .filter_map(|t| t.team_name.as_ref())
+                                .cloned()
+                                .collect();
+                            debug!("   Associated teams: {}", team_names.join(", "));
+                        }
+                        info!("✅ Application ready: {app_profile_name}");
+                        app
+                    }
+                    Err(ref e)
+                        if matches!(
+                            e,
+                            veracode_platform::VeracodeError::Authentication(_)
+                                | veracode_platform::VeracodeError::HttpStatus {
+                                    status_code: 401 | 403,
+                                    ..
+                                }
+                        ) && attempt < MAX_ATTEMPTS =>
+                    {
+                        warn!(
+                            "⚠️  Authentication error during app lookup \
+                             (attempt {attempt}/{MAX_ATTEMPTS}), refreshing credentials..."
+                        );
+                        match try_refresh_assessment_submitter(
+                            &args.region,
+                            &current_submitter.config,
+                        )
+                        .await
+                        {
+                            Some((new_sub, _)) => {
+                                current_submitter = new_sub;
+                                continue;
+                            }
+                            None => return Err(1),
+                        }
+                    }
+                    Err(e) => {
+                        error!(
+                            "❌ Failed to lookup or create application '{app_profile_name}': {e}"
+                        );
+                        return Err(1);
+                    }
+                };
+
+                let app_id = crate::assessment::ApplicationId::new(app.guid, app.id.to_string());
+
+                match current_submitter
+                    .setup_and_start_prescan(matched_files, &app_id)
+                    .await
+                {
+                    Ok((build_id, sandbox_id)) => break (app_id, build_id, sandbox_id),
+                    Err(ref e) if crate::assessment::is_auth_error(e) && attempt < MAX_ATTEMPTS => {
+                        warn!(
+                            "⚠️  Authentication error during scan setup \
+                             (attempt {attempt}/{MAX_ATTEMPTS}), refreshing credentials..."
+                        );
+                        match try_refresh_assessment_submitter(
+                            &args.region,
+                            &current_submitter.config,
+                        )
+                        .await
+                        {
+                            Some((new_sub, _)) => current_submitter = new_sub,
+                            None => return Err(1),
+                        }
+                    }
+                    Err(e) => {
+                        error!("❌ Assessment scan setup failed: {e}");
+                        return Err(1);
+                    }
                 }
-                info!("✅ Application ready: {app_profile_name}");
-                crate::assessment::ApplicationId::new(app.guid, app.id.to_string())
-            }
-            Err(e) => {
-                error!("❌ Failed to lookup or create application '{app_profile_name}': {e}");
-                return Err(1);
             }
         };
 
-        // Upload files and start scan
-        match submitter.upload_and_scan(matched_files, &app_id).await {
-            Ok(build_id) => {
-                info!("✅ Assessment scan workflow completed");
-                info!("   Build ID: {build_id}");
-                info!("   App Profile: {app_profile_name}");
-                match &submitter.config.scan_type {
-                    ScanType::Sandbox => {
-                        if let Some(sandbox_name) = &submitter.config.sandbox_name {
-                            info!("   Sandbox: {sandbox_name}");
+        // ── Phase 2: Monitor + export ────────────────────────────────────────
+        // On 401/403, refresh credentials and resume monitoring with the same
+        // build_id and sandbox_id — the scan keeps running on Veracode's servers.
+        {
+            let mut attempt = 0u32;
+            loop {
+                attempt = attempt.saturating_add(1);
+                match current_submitter
+                    .run_monitoring_and_export(&app_id, &build_id, sandbox_id.as_ref())
+                    .await
+                {
+                    Ok(()) => break,
+                    Err(ref e) if crate::assessment::is_auth_error(e) && attempt < MAX_ATTEMPTS => {
+                        warn!(
+                            "⚠️  Authentication error during scan monitoring \
+                             (attempt {attempt}/{MAX_ATTEMPTS}), refreshing credentials from Vault..."
+                        );
+                        match try_refresh_assessment_submitter(
+                            &args.region,
+                            &current_submitter.config,
+                        )
+                        .await
+                        {
+                            Some((new_sub, _)) => {
+                                info!(
+                                    "✅ Credentials refreshed, resuming monitoring with same \
+                                     build ID (attempt {}/{MAX_ATTEMPTS})...",
+                                    attempt.saturating_add(1)
+                                );
+                                current_submitter = new_sub;
+                            }
+                            None => return Err(1),
                         }
                     }
-                    ScanType::Policy => {
-                        info!("   Scan Type: Policy");
+                    Err(e) => {
+                        error!("❌ Assessment scan failed: {e}");
+                        return Err(1);
                     }
                 }
-                Ok(())
-            }
-            Err(e) => {
-                error!("❌ Assessment scan failed: {e}");
-                Err(1)
             }
         }
+
+        info!("✅ Assessment scan workflow completed");
+        info!("   Build ID: {build_id}");
+        info!("   App Profile: {app_profile_name}");
+        match &current_submitter.config.scan_type {
+            ScanType::Sandbox => {
+                if let Some(sandbox_name) = &current_submitter.config.sandbox_name {
+                    info!("   Sandbox: {sandbox_name}");
+                }
+            }
+            ScanType::Policy => {
+                info!("   Scan Type: Policy");
+            }
+        }
+        Ok(())
     } else {
         error!("❌ execute_assessment_scan_async called with non-assessment command");
         Err(1)

--- a/verascan/src/vault_client.rs
+++ b/verascan/src/vault_client.rs
@@ -495,8 +495,15 @@ fn create_vault_client(config: &VaultConfig) -> Result<VaultClient, CredentialEr
         .map(|v| v != "true")
         .unwrap_or(true);
 
+    let ca_certs = std::env::var("VAULT_CACERT")
+        .map(|p| vec![p])
+        .unwrap_or_else(|_| vec!["/etc/ssl/certs/ca-certificates.crt".to_string()]);
+
     let mut settings_builder = VaultClientSettingsBuilder::default();
-    settings_builder.address(&config.addr).verify(verify_certs);
+    settings_builder
+        .address(&config.addr)
+        .verify(verify_certs)
+        .ca_certs(ca_certs);
 
     if let Some(ref namespace) = config.namespace {
         settings_builder.namespace(Some(namespace.clone()));

--- a/verascan/src/vault_client.rs
+++ b/verascan/src/vault_client.rs
@@ -371,6 +371,46 @@ pub async fn load_credentials_and_proxy_from_vault() -> Result<
     Ok((credentials, None, None, None))
 }
 
+/// Refresh `VeracodeCredentials` and proxy configuration from Vault (no env fallback).
+///
+/// This is used when credentials may have expired mid-operation (e.g., 401/403 during
+/// a scan submission). Unlike `load_credentials_and_proxy_from_vault`, this function
+/// requires Vault to be configured and does not fall back to environment variables.
+///
+/// # Errors
+/// Returns an error if Vault is not configured or credential retrieval fails.
+pub async fn refresh_credentials_from_vault() -> Result<
+    (
+        veracode_platform::VeracodeCredentials,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ),
+    CredentialError,
+> {
+    info!("Attempting to refresh credentials from Vault due to authentication error");
+
+    let vault_config = load_vault_config_from_env()?;
+    let vault_client = VaultCredentialClient::new(&vault_config).await?;
+
+    let credentials = vault_client
+        .get_veracode_credentials(&vault_config.secret_path)
+        .await?;
+
+    let (proxy_url, proxy_username, proxy_password) = vault_client
+        .get_proxy_credentials(&vault_config.secret_path)
+        .await?;
+
+    if let Err(e) = vault_client.revoke_token().await {
+        warn!("Token revocation failed during credential refresh: {e}");
+    } else {
+        debug!("Vault token revoked successfully after credential refresh");
+    }
+
+    info!("Successfully refreshed credentials from Vault");
+    Ok((credentials, proxy_url, proxy_username, proxy_password))
+}
+
 /// Validate vault configuration with comprehensive input sanitization
 fn validate_vault_config(
     addr: &str,


### PR DESCRIPTION
## Summary

- **Root cause**: The reqwest 0.12 → 0.13 upgrade in v0.7.1 split the reqwest dependency graph. vaultrs retained its own `reqwest 0.12.28` instance and lost the `rustls-tls-native-roots` feature it previously inherited via Cargo feature unification, causing Vault TLS connections to stop trusting CAs in `/etc/ssl/certs/ca-certificates.crt`
- **Fix**: Explicitly call `.ca_certs()` on `VaultClientSettingsBuilder` in `create_vault_client()` for both verascan and veracmek, loading the system CA bundle as a fallback when `VAULT_CACERT` is not set in the environment
- **Precedence preserved**: `VAULT_CACERT` env var still takes priority over the system bundle fallback

## Changes

- `verascan/src/vault_client.rs` — added `.ca_certs()` call with system CA bundle fallback
- `veracmek/src/vault_client.rs` — same fix applied
- `verascan/Cargo.toml` — explicitly enabled `rustls` feature on `vaultrs`; bumped to v0.7.2
- `veracmek/Cargo.toml` — explicitly enabled `rustls` feature on `vaultrs`; bumped to v0.5.14
- `verascan/CHANGELOG.md` — added v0.7.2 release notes
- `veracmek/CHANGELOG.md` — added v0.5.14 release notes

## Test plan

- [x] Deploy against a Vault instance using a certificate signed by an internal/enterprise CA present in `/etc/ssl/certs/ca-certificates.crt` — connection should succeed without setting `VAULT_CACERT`
- [x] Verify `VAULT_CACERT=/path/to/custom.pem` still overrides the system bundle when set
- [x] Verify `VERASCAN_DISABLE_CERT_VALIDATION=true` / `VERACMEK_DISABLE_CERT_VALIDATION=true` still bypasses cert checks as before
- [x] Run `cargo build -p verascan -p veracmek` — should compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)