### PR TITLE
feat: Add monitor subcommand and --no-wait build ID file for assessment (verascan v0.7.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "veracode-platform"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "async-stream",
  "bytes",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "verascan"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "backon",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,27 +57,12 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -90,15 +75,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -198,9 +174,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -208,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -252,9 +228,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -303,9 +279,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -350,7 +326,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -420,7 +396,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -446,9 +422,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -791,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -801,11 +777,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -841,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1039,7 +1015,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1111,6 +1087,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1186,9 +1168,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1201,7 +1183,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1209,15 +1190,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1273,12 +1253,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1286,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1299,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1313,15 +1294,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1333,15 +1314,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1387,12 +1368,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1414,9 +1395,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1439,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -1476,7 +1457,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1485,9 +1466,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -1501,19 +1504,21 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonschema"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
+checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1552,9 +1557,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1574,9 +1579,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1623,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1826,12 +1831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1913,15 +1912,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1975,7 +1974,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2024,9 +2023,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2034,13 +2033,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2064,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2079,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2128,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
+checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2268,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustify"
@@ -2321,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2385,9 +2384,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2478,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2746,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2781,9 +2780,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -2814,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3025,9 +3024,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3137,7 +3136,7 @@ dependencies = [
  "log",
  "proptest",
  "quick-xml",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.2",
  "secrecy",
@@ -3249,9 +3248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3262,23 +3261,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3286,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3299,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3355,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3816,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xxhash-rust"
@@ -3828,9 +3823,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3839,9 +3834,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3851,18 +3846,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3871,18 +3866,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3898,9 +3893,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3909,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3920,9 +3915,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = { version = "0.13", features = ["json", "multipart", "rustls"], defaul
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 thiserror = "2.0"
 
 # Profile for running tests with miri

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ veracode-workspace/
 
 ### [Veracode API Library](veracode-api/) (`veracode-api`)
 
-[![Crate Version](https://img.shields.io/badge/version-0.7.5-blue.svg)](veracode-api/Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.7.11-blue.svg)](veracode-api/Cargo.toml)
 
 A comprehensive Rust client library for the Veracode security platform APIs.
 
@@ -78,7 +78,7 @@ A comprehensive Rust client library for the Veracode security platform APIs.
 
 ### [Verascan CLI](verascan/) (`verascan`)
 
-[![Crate Version](https://img.shields.io/badge/version-0.7.2-blue.svg)](verascan/Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.7.4-blue.svg)](verascan/Cargo.toml)
 
 A powerful command-line application for security scanning and Veracode integration.
 

--- a/veraaudit/Cargo.toml
+++ b/veraaudit/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 # Local dependency
-veracode-platform = { path = "../veracode-api", version = "0.7.9" }
+veracode-platform = { path = "../veracode-api", version = "0.7.11" }
 
 # Additional dependencies for CLI functionality
 env_logger = "0.11"

--- a/veracmek/Cargo.toml
+++ b/veracmek/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 # Local dependency
-veracode-platform = { path = "../veracode-api", version = "0.7.9" }
+veracode-platform = { path = "../veracode-api", version = "0.7.11" }
 
 # Additional dependencies for CLI functionality
 env_logger = "0.11"

--- a/veracode-api/CHANGELOG.md
+++ b/veracode-api/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the veracode-platform crate will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.11] - 2026-04-15
+
+### Fixed
+- **Policy evaluation retry exhaustion now returns `Err` instead of `Ok("Not Assessed")`**: `evaluate_policy_compliance_via_buildinfo_with_retry` previously returned `Ok(Cow::Borrowed("Not Assessed"))` when all retries were consumed, making it impossible for callers to distinguish a genuine "Not Assessed" policy state from a timeout waiting for evaluation to complete
+  - Now returns `Err(PolicyError::Timeout)` on retry exhaustion so callers can handle the two cases separately
+  - **Modified Files**: `src/policy.rs`
+
 ## [0.7.10] - 2026-03-18
 
 ### Added

--- a/veracode-api/Cargo.toml
+++ b/veracode-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veracode-platform"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2024"
 authors = ["Fred Nollows <frednollows@gmail.com>"]
 description = "A comprehensive Rust client library for the Veracode platform (Applications, Identity, Pipeline Scan, Sandbox)"

--- a/veracode-api/README.md
+++ b/veracode-api/README.md
@@ -42,7 +42,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-veracode-platform = "0.7.9"
+veracode-platform = "0.7.11"
 tokio = { version = "1.0", features = ["full"] }
 ```
 

--- a/veracode-api/README.md
+++ b/veracode-api/README.md
@@ -832,7 +832,7 @@ Enable only the APIs you need to reduce compile time and binary size:
 
 ```toml
 [dependencies]
-veracode-platform = { version = "0.1.0", features = ["pipeline", "applications"] }
+veracode-platform = { version = "0.7.11", features = ["pipeline", "applications"] }
 ```
 
 Available features:

--- a/veracode-api/src/build.rs
+++ b/veracode-api/src/build.rs
@@ -818,32 +818,30 @@ impl BuildApi {
                         _ => {}
                     }
                 }
-                Ok(Event::Empty(ref e)) => {
+                Ok(Event::Empty(ref e))
                     // Handle self-closing elements like <analysis_unit ... />
-                    if e.name().as_ref() == b"analysis_unit" && inside_build {
-                        for attr in e.attributes().flatten() {
-                            let key = String::from_utf8_lossy(attr.key.as_ref());
-                            let value = String::from_utf8_lossy(&attr.value);
+                    if e.name().as_ref() == b"analysis_unit" && inside_build => {
+                    for attr in e.attributes().flatten() {
+                        let key = String::from_utf8_lossy(attr.key.as_ref());
+                        let value = String::from_utf8_lossy(&attr.value);
 
-                            match key.as_ref() {
-                                "status" => {
-                                    build
-                                        .attributes
-                                        .insert("status".to_string(), value.into_owned());
-                                }
-                                _ => {
-                                    build
-                                        .attributes
-                                        .insert(format!("analysis_{key}"), value.into_owned());
-                                }
+                        match key.as_ref() {
+                            "status" => {
+                                build
+                                    .attributes
+                                    .insert("status".to_string(), value.into_owned());
+                            }
+                            _ => {
+                                build
+                                    .attributes
+                                    .insert(format!("analysis_{key}"), value.into_owned());
                             }
                         }
                     }
                 }
-                Ok(Event::End(ref e)) => {
-                    if e.name().as_ref() == b"build" {
-                        inside_build = false;
-                    }
+                Ok(Event::End(ref e))
+                    if e.name().as_ref() == b"build" => {
+                    inside_build = false;
                 }
                 Ok(Event::Eof) => break,
                 Err(e) => return Err(BuildError::XmlParsingError(e.to_string())),
@@ -987,18 +985,17 @@ impl BuildApi {
                     }
                     _ => {}
                 },
-                Ok(Event::Empty(ref e)) => {
+                Ok(Event::Empty(ref e))
                     // Handle self-closing build tags like <build ... />
-                    if e.name().as_ref() == b"build" {
-                        let build = self.parse_build_from_attributes(
-                            e.attributes(),
-                            &build_list.app_id,
-                            &build_list.app_name,
-                        );
+                    if e.name().as_ref() == b"build" => {
+                    let build = self.parse_build_from_attributes(
+                        e.attributes(),
+                        &build_list.app_id,
+                        &build_list.app_name,
+                    );
 
-                        if !build.build_id.is_empty() {
-                            build_list.builds.push(build);
-                        }
+                    if !build.build_id.is_empty() {
+                        build_list.builds.push(build);
                     }
                 }
                 Ok(Event::Eof) => break,
@@ -1021,12 +1018,10 @@ impl BuildApi {
 
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => {
-                    if e.name().as_ref() == b"result" {
-                        // Read the text content of the result element
-                        if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) {
-                            result = String::from_utf8_lossy(&e).into_owned();
-                        }
+                Ok(Event::Start(ref e)) if e.name().as_ref() == b"result" => {
+                    // Read the text content of the result element
+                    if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) {
+                        result = String::from_utf8_lossy(&e).into_owned();
                     }
                 }
                 Ok(Event::Eof) => break,

--- a/veracode-api/src/policy.rs
+++ b/veracode-api/src/policy.rs
@@ -944,13 +944,14 @@ impl<'a> PolicyApi<'a> {
                 return Ok(Cow::Owned(status.to_string()));
             }
 
-            // If we've reached max retries, return "Not Assessed"
+            // If we've reached max retries, return a Timeout error so callers can
+            // distinguish "timed out waiting" from "policy genuinely not assigned"
             attempts = attempts.saturating_add(1);
             if attempts >= max_retries {
                 warn!(
                     "Policy evaluation still not assessed after {max_retries} attempts. This may indicate: scan is still in progress, policy evaluation is taking longer than expected, or application may not have a policy assigned"
                 );
-                return Ok(Cow::Borrowed("Not Assessed"));
+                return Err(PolicyError::Timeout);
             }
 
             // Log retry attempt

--- a/veracode-api/src/scan.rs
+++ b/veracode-api/src/scan.rs
@@ -1416,10 +1416,8 @@ impl ScanApi {
                         }
                     }
                 }
-                Ok(Event::End(ref e)) => {
-                    if e.name().as_ref() == b"error" {
-                        in_error_tag = false;
-                    }
+                Ok(Event::End(ref e)) if e.name().as_ref() == b"error" => {
+                    in_error_tag = false;
                 }
                 Ok(Event::Eof) => break,
                 Err(e) => {
@@ -1538,10 +1536,8 @@ impl ScanApi {
                 b"type" => module.module_type = attr_to_string(&attr.value),
                 b"isfatal" => module.is_fatal = attr.value.as_ref() == b"true",
                 b"selected" => module.selected = attr.value.as_ref() == b"true",
-                b"has_fatal_errors" => {
-                    if attr.value.as_ref() == b"true" {
-                        *has_fatal_errors = true;
-                    }
+                b"has_fatal_errors" if attr.value.as_ref() == b"true" => {
+                    *has_fatal_errors = true;
                 }
                 b"size" => {
                     if let Ok(size_str) = String::from_utf8(attr.value.to_vec()) {
@@ -1608,13 +1604,12 @@ impl ScanApi {
                         _ => {}
                     }
                 }
-                Ok(Event::Empty(ref e)) => {
+                Ok(Event::Empty(ref e))
                     // Handle self-closing module tags like <module ... />
-                    if e.name().as_ref() == b"module" {
-                        let module = self
-                            .parse_module_from_attributes(e.attributes(), &mut has_fatal_errors);
-                        modules.push(module);
-                    }
+                    if e.name().as_ref() == b"module" => {
+                    let module = self
+                        .parse_module_from_attributes(e.attributes(), &mut has_fatal_errors);
+                    modules.push(module);
                 }
                 Ok(Event::Eof) => break,
                 Err(e) => {
@@ -1715,22 +1710,19 @@ impl ScanApi {
                         in_error_tag = true;
                     }
                 }
-                Ok(Event::Empty(ref e)) => {
+                Ok(Event::Empty(ref e))
                     // Handle self-closing file tags like <file ... />
-                    if e.name().as_ref() == b"file" {
-                        let file = self.parse_file_from_attributes(e.attributes());
-                        files.push(file);
-                    }
+                    if e.name().as_ref() == b"file" => {
+                    let file = self.parse_file_from_attributes(e.attributes());
+                    files.push(file);
                 }
-                Ok(Event::Text(ref e)) => {
-                    if in_error_tag {
-                        current_error = Some(String::from_utf8_lossy(e).to_string());
-                    }
+                Ok(Event::Text(ref e))
+                    if in_error_tag => {
+                    current_error = Some(String::from_utf8_lossy(e).to_string());
                 }
-                Ok(Event::End(ref e)) => {
-                    if e.name().as_ref() == b"error" {
-                        in_error_tag = false;
-                    }
+                Ok(Event::End(ref e))
+                    if e.name().as_ref() == b"error" => {
+                    in_error_tag = false;
                 }
                 Ok(Event::Eof) => break,
                 Err(e) => {
@@ -1784,11 +1776,10 @@ impl ScanApi {
                             for attr in e.attributes().flatten() {
                                 match attr.key.as_ref() {
                                     b"build_id" => scan_info.build_id = attr_to_string(&attr.value),
-                                    b"analysis_unit" => {
+                                    b"analysis_unit"
                                         // Fallback status from buildinfo (older API format)
-                                        if scan_info.status == "Unknown" {
-                                            scan_info.status = attr_to_string(&attr.value);
-                                        }
+                                        if scan_info.status == "Unknown" => {
+                                        scan_info.status = attr_to_string(&attr.value);
                                     }
                                     b"analysis_unit_id" => {
                                         scan_info.analysis_unit_id =
@@ -1834,24 +1825,22 @@ impl ScanApi {
                         _ => {}
                     }
                 }
-                Ok(Event::End(ref e)) => {
-                    if e.name().as_ref() == b"build" {
-                        inside_build = false;
-                    }
+                Ok(Event::End(ref e))
+                    if e.name().as_ref() == b"build" => {
+                    inside_build = false;
                 }
-                Ok(Event::Empty(ref e)) => {
+                Ok(Event::Empty(ref e))
                     // Handle self-closing elements like <analysis_unit ... />
-                    if e.name().as_ref() == b"analysis_unit" && inside_build {
-                        for attr in e.attributes().flatten() {
-                            match attr.key.as_ref() {
-                                b"status" => {
-                                    scan_info.status = attr_to_string(&attr.value);
-                                }
-                                b"analysis_type" => {
-                                    scan_info.scan_type = attr_to_string(&attr.value);
-                                }
-                                _ => {}
+                    if e.name().as_ref() == b"analysis_unit" && inside_build => {
+                    for attr in e.attributes().flatten() {
+                        match attr.key.as_ref() {
+                            b"status" => {
+                                scan_info.status = attr_to_string(&attr.value);
                             }
+                            b"analysis_type" => {
+                                scan_info.scan_type = attr_to_string(&attr.value);
+                            }
+                            _ => {}
                         }
                     }
                 }

--- a/verascan/CHANGELOG.md
+++ b/verascan/CHANGELOG.md
@@ -5,7 +5,29 @@ All notable changes to verascan will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.4] - 2026-04-15
+
+### Added
+- **`monitor` subcommand**: New `verascan monitor` command reconnects to an in-progress assessment scan by build ID, designed for CI pipelines (e.g. GitLab) where the scan was submitted with `--no-wait` in a prior job
+  - Accepts `--app-profile-name`, `--build-id` (or `VERASCAN_BUILD_ID` env var), optional `--sandbox-name`, `--timeout` (default 55 minutes), `--export-results`, `--break`, `--force-buildinfo-api`, `--strict-sandbox`
+  - Exit codes: `0` (complete, policy passed or `--break` not set), `4` (policy Did Not Pass with `--break`), `75` (scan still in progress after `--timeout` — safe to retry the CI job), `1` (unrecoverable error)
+  - Supports Vault credential refresh on mid-poll auth errors with the same auth-retry pattern used by the `assessment` command
+  - **Modified Files**: `src/cli.rs`, `src/scan.rs`, `src/assessment.rs`, `src/lib.rs`, `src/main.rs`, `src/search.rs`
+- **`--build-id-file` flag for `assessment`**: When using `--no-wait`, the build ID is written to a file as `VERASCAN_BUILD_ID="<id>"` for CI artifact passing between jobs (default: `vid.env`)
+  - **Modified Files**: `src/cli.rs`, `src/scan.rs`
+
+### Changed
+- **Name field length limit raised from 70 to 256 characters**: `--app-profile-name` and other name fields now accept up to 256 characters to accommodate longer Veracode application profile names
+  - **Modified Files**: `src/cli.rs`
+
+### Fixed
+- **Monitoring Timeout Resets on Credential Refresh**: The monitoring deadline is now anchored to a single `std::time::Instant` computed once before the auth-retry loop, so a Vault credential rotation mid-poll no longer resets the timeout clock
+  - Previously, each call to `run_monitoring_and_export` after an `AuthError` restarted from `config.timeout` in full — a rotation at minute 29 of a `--timeout 30` job could extend wall-clock time to 59 minutes
+  - The deadline is now passed through `run_monitoring_and_export` → `monitor_scan_progress` / `monitor_prescan_phase` / `monitor_build_phase` / `monitor_policy_evaluation`, where each phase computes `max_polls` from remaining time rather than the configured timeout value
+  - Applies to both `assessment` and `monitor` subcommands
+  - **Modified Files**: `src/assessment.rs`, `src/scan.rs`
+
+## [0.7.3] - 2026-04-15
 
 ### Fixed
 - **Cancelled Build Detection**: Verascan now exits immediately when a build is cancelled through the Veracode web interface instead of polling until timeout

--- a/verascan/CHANGELOG.md
+++ b/verascan/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Modified Files**: `src/cli.rs`
 
 ### Fixed
+- **Policy evaluation phase (Phase 3) exits with code 75 on timeout for `monitor` command**: `monitor_policy_evaluation` previously declared Phase 3 complete with `✅` even when policy status was still "Not Assessed" after retries exhausted, then `export_scan_results` would silently start a second independent retry loop (30 attempts × 10s) outside the deadline
+  - Phase 3 now correctly propagates `PolicyError::Timeout` from `veracode-platform` as `ScanStillInProgress` (exit 75) when `--timeout` is reached in the `monitor` subcommand, or `ScanError` (exit 1) in the `assessment` subcommand — consistent with Phases 1 and 2
+  - Because Phase 3 errors now propagate via `?`, `export_scan_results` is never reached on timeout, so the export's independent policy retry loop no longer runs outside the deadline
+  - **Modified Files**: `src/assessment.rs`
 - **Monitoring Timeout Resets on Credential Refresh**: The monitoring deadline is now anchored to a single `std::time::Instant` computed once before the auth-retry loop, so a Vault credential rotation mid-poll no longer resets the timeout clock
   - Previously, each call to `run_monitoring_and_export` after an `AuthError` restarted from `config.timeout` in full — a rotation at minute 29 of a `--timeout 30` job could extend wall-clock time to 59 minutes
   - The deadline is now passed through `run_monitoring_and_export` → `monitor_scan_progress` / `monitor_prescan_phase` / `monitor_build_phase` / `monitor_policy_evaluation`, where each phase computes `max_polls` from remaining time rather than the configured timeout value

--- a/verascan/Cargo.toml
+++ b/verascan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verascan"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 authors = ["Fred Nollows <frednollows@gmail.com>"]
 description = "A comprehensive Rust client application for the Veracode platform to support pipeline, sandbox and policy scan submission and reporting."
@@ -44,7 +44,7 @@ doc_markdown = "warn"                  # Enforces markdown in docs
 
 [dependencies]
 # Veracode Platform client library
-veracode-platform = { path = "../veracode-api", version = "0.7.9" }
+veracode-platform = { path = "../veracode-api", version = "0.7.11" }
 
 # CLI and utilities
 clap = { workspace = true, features = ["derive"] }

--- a/verascan/README.md
+++ b/verascan/README.md
@@ -2,7 +2,7 @@
 
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-brightgreen.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Crate Version](https://img.shields.io/badge/version-0.7.2-blue.svg)](Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.7.4-blue.svg)](Cargo.toml)
 
 A comprehensive Rust CLI application for the Veracode platform to support pipeline, sandbox and policy scan submission and reporting.
 
@@ -46,6 +46,12 @@ A comprehensive Rust CLI application for the Veracode platform to support pipeli
 - **CSV**: Spreadsheet-compatible findings export
 - **GitLab SAST**: Security Dashboard integration
 - **Filtered JSON**: Policy violation reports
+
+### Assessment Monitor (Two-Job CI Pattern)
+- `monitor` subcommand reconnects to an in-progress assessment scan by build ID
+- Designed for CI pipelines where the upload job uses `--no-wait` and a follow-on job monitors to completion
+- Exit code `75` when the scan is still in progress after `--timeout` — GitLab CI can be configured to automatically retry the job
+- Supports Vault credential refresh mid-poll with the same auth-retry pattern as the `assessment` command
 
 ### Export from Completed Scans
 - Findings retrieval from completed Veracode assessment scans
@@ -165,7 +171,41 @@ verascan assessment --filepath ./target \
   --app-profile-name "MyApplication" \
   --build-version "v2.1.0-release" \
   --export-results results.json
+
+# Submit scan without waiting; write build ID to file for a follow-on monitor job
+verascan assessment --filepath ./target \
+  --app-profile-name "MyApplication" \
+  --no-wait \
+  --build-id-file vid.env
 ```
+
+### Monitoring an In-Progress Assessment Scan
+
+The `monitor` subcommand reconnects to a scan that was submitted with `--no-wait` in a prior CI job.
+
+```bash
+# Monitor by build ID (reads VERASCAN_BUILD_ID from environment or --build-id flag)
+verascan monitor \
+  --app-profile-name "MyApplication" \
+  --build-id "$VERASCAN_BUILD_ID" \
+  --timeout 55 \
+  --export-results assessment-results.json \
+  --break
+
+# Monitor a sandbox scan
+verascan monitor \
+  --app-profile-name "MyApplication" \
+  --sandbox-name "development-sandbox" \
+  --build-id "$VERASCAN_BUILD_ID" \
+  --timeout 55 \
+  --export-results sandbox-results.json
+```
+
+Exit codes from `monitor`:
+- `0` — scan complete, policy passed (or `--break` not set)
+- `4` — scan complete, policy Did Not Pass (with `--break`)
+- `75` — scan still in progress after `--timeout`; safe to retry the CI job
+- `1` — unrecoverable error (app not found, API failure, etc.)
 
 ### Export from Completed Scans
 
@@ -263,14 +303,33 @@ verascan assessment [OPTIONS] --filepath <PATH> --app-profile-name <NAME>
 
 **Key Options:**
 - `--filepath <PATH>` - Directory to scan for files (required)
-- `--app-profile-name <NAME>` - Veracode application profile name (required)
+- `--app-profile-name <NAME>` - Veracode application profile name (required, up to 256 characters)
 - `--sandbox-name <NAME>` - Sandbox name for sandbox scans
 - `--build-version <VERSION>` - Custom build version (auto-generated if not specified)
 - `--export-results <FILE>` - Export assessment results
 - `--break` - Break build on Veracode platform policy failure
-- `--no-wait` - Submit scan and exit without waiting
+- `--no-wait` - Submit scan and exit without waiting for completion
+- `--build-id-file <FILE>` - File to write `VERASCAN_BUILD_ID="<id>"` when using `--no-wait` (default: `vid.env`)
 - `--threads <COUNT>` - Concurrent threads 2-10 (default: `4`)
 - `--timeout <MINUTES>` - Scan timeout in minutes (default: `60`)
+
+### Monitor Command
+
+```bash
+verascan monitor [OPTIONS] --app-profile-name <NAME>
+```
+
+Reconnects to an in-progress assessment scan submitted via `--no-wait`. Intended for multi-job CI pipelines.
+
+**Key Options:**
+- `--app-profile-name <NAME>` - Veracode application profile name (required)
+- `--build-id <ID>` - Build ID from a previous `--no-wait` scan; can be omitted when `VERASCAN_BUILD_ID` is set in the environment (one or the other is required)
+- `--sandbox-name <NAME>` - Sandbox name (required if the original scan targeted a sandbox)
+- `--timeout <MINUTES>` - Maximum minutes to monitor before exiting with code 75 (default: `55`)
+- `--export-results <FILE>` - Export results on completion (default: `assessment-results.json`)
+- `--break` - Break build (exit code 4) on Veracode platform policy failure
+- `--force-buildinfo-api` - Force XML API for policy evaluation
+- `--strict-sandbox` - Exit code 4 on sandbox Conditional Pass
 
 ### Export Command
 
@@ -293,6 +352,7 @@ verascan export [OPTIONS] --app-profile-name <NAME> --output <FILE>
 |----------|----------|-------------|
 | `VERACODE_API_ID` | ✅ | Your Veracode API ID credential |
 | `VERACODE_API_KEY` | ✅ | Your Veracode API key credential |
+| `VERASCAN_BUILD_ID` | — | Build ID written by `--no-wait`; consumed by `verascan monitor --build-id` |
 
 ### API Configuration
 | Variable | Default | Description |
@@ -325,7 +385,7 @@ verascan export [OPTIONS] --app-profile-name <NAME> --output <FILE>
 
 ## CI/CD Integration
 
-### GitLab CI
+### GitLab CI — Pipeline Scan
 
 ```yaml
 stages:
@@ -348,6 +408,47 @@ security_scan:
   artifacts:
     reports:
       sast: gl-sast-report.json
+    when: always
+```
+
+### GitLab CI — Assessment Scan (Two-Job Pattern)
+
+For long-running assessment scans, split submission and monitoring into separate jobs so GitLab can retry the monitor job (exit 75) without re-uploading files:
+
+```yaml
+stages:
+  - upload
+  - monitor
+
+verascan_upload:
+  stage: upload
+  script:
+    - verascan assessment --filepath ./target
+        --app-profile-name "MyApplication"
+        --no-wait
+        --build-id-file vid.env
+  artifacts:
+    paths:
+      - vid.env  # passes VERASCAN_BUILD_ID to the monitor job
+    expire_in: 2 hours
+
+verascan_monitor:
+  stage: monitor
+  retry:
+    max: 5
+    when: exit_codes
+    exit_codes:
+      - 75  # scan still in progress — safe to retry
+  script:
+    - source vid.env   # exports VERASCAN_BUILD_ID — --build-id flag not needed
+    - verascan monitor
+        --app-profile-name "MyApplication"
+        --timeout 55
+        --export-results assessment-results.json
+        --break
+  artifacts:
+    paths:
+      - assessment-results.json
     when: always
 ```
 
@@ -381,10 +482,11 @@ jobs:
 
 | Code | Meaning |
 |------|---------|
-| `0` | Success - no policy violations found |
+| `0` | Success — no policy violations found |
 | `1` | Policy violations detected or scan errors |
 | `2` | Configuration or authentication errors |
 | `4` | Veracode platform policy failure (when using `--break` flag) |
+| `75` | Scan still in progress after `--timeout` (`monitor` subcommand only) — safe to retry the CI job |
 
 ## Severity Levels
 

--- a/verascan/examples/gitlab_ci_assessment_monitor.yml
+++ b/verascan/examples/gitlab_ci_assessment_monitor.yml
@@ -1,0 +1,114 @@
+# GitLab CI — Veracode Assessment scan using the two-job --no-wait / monitor pattern
+#
+# How it works:
+#   1. verascan_upload  — uploads artifacts and starts the scan, then exits immediately
+#                         (--no-wait). Writes the build ID to vid.env and passes it as
+#                         a job artifact to the next stage.
+#   2. verascan_monitor — sources vid.env (sets VERASCAN_BUILD_ID in the shell
+#                         environment, which verascan monitor reads automatically) and
+#                         polls until the scan finishes or the job times out.
+#                         Exit code 75 means the scan is still running; GitLab retries
+#                         the job automatically up to 5 times (≈5 hours of wall time
+#                         with a 55-minute timeout per attempt).
+#
+# Required CI/CD variables (Settings → CI/CD → Variables):
+#   VERACODE_API_ID   — Veracode API ID
+#   VERACODE_API_KEY  — Veracode API key
+#
+# Optional CI/CD variables:
+#   VERASCAN_VERSION  — verascan binary version to download (default: latest)
+#   VERACODE_REGION   — commercial | european | federal (default: commercial)
+
+stages:
+  - upload
+  - monitor
+
+# ---------------------------------------------------------------------------
+# Shared configuration
+# ---------------------------------------------------------------------------
+
+.verascan_common:
+  image: debian:bookworm-slim
+  before_script:
+    # Download the pre-built verascan binary. Replace the URL with your
+    # internal package registry or artifact store as appropriate.
+    - apt-get update -qq && apt-get install -y -qq curl ca-certificates
+    - |
+      VERASCAN_VERSION="${VERASCAN_VERSION:-latest}"
+      echo "Downloading verascan ${VERASCAN_VERSION}..."
+      curl -fsSL \
+        "https://your-registry.example.com/verascan/${VERASCAN_VERSION}/verascan-linux-amd64" \
+        -o /usr/local/bin/verascan
+      chmod +x /usr/local/bin/verascan
+      verascan --version
+  variables:
+    VERACODE_API_ID: $VERACODE_API_ID
+    VERACODE_API_KEY: $VERACODE_API_KEY
+    VERACODE_REGION: ${VERACODE_REGION:-commercial}
+
+# ---------------------------------------------------------------------------
+# Stage 1 — Upload artifacts and start scan (exits immediately)
+# ---------------------------------------------------------------------------
+
+verascan_upload:
+  extends: .verascan_common
+  stage: upload
+  script:
+    - echo "Starting Veracode assessment scan (--no-wait)..."
+    - |
+      verascan assessment \
+        --filepath "${CI_PROJECT_DIR}/build" \
+        --app-profile-name "${CI_PROJECT_NAME}" \
+        --region "${VERACODE_REGION}" \
+        --no-wait \
+        --build-id-file vid.env \
+        --build-version "${CI_COMMIT_SHORT_SHA}-${CI_PIPELINE_ID}"
+    - echo "Scan submitted. Build ID:"
+    - cat vid.env
+  artifacts:
+    paths:
+      - vid.env       # consumed by verascan_monitor via VERASCAN_BUILD_ID
+    expire_in: 8 hours
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_MERGE_REQUEST_IID
+
+# ---------------------------------------------------------------------------
+# Stage 2 — Monitor until complete; retry on timeout (exit 75)
+# ---------------------------------------------------------------------------
+
+verascan_monitor:
+  extends: .verascan_common
+  stage: monitor
+  # Each attempt polls for up to 55 minutes. GitLab retries the job when
+  # verascan exits with code 75 (scan still in progress). With 5 retries
+  # the total monitoring window is up to ~5 hours before the pipeline fails.
+  timeout: 60 minutes
+  retry:
+    max: 5
+    when: exit_codes
+    exit_codes:
+      - 75    # scan still in progress — safe to retry
+  script:
+    # Source vid.env to set VERASCAN_BUILD_ID in the environment.
+    # verascan monitor reads it automatically; no --build-id flag needed.
+    - source vid.env
+    - echo "Monitoring build ID ${VERASCAN_BUILD_ID}..."
+    - |
+      verascan monitor \
+        --app-profile-name "${CI_PROJECT_NAME}" \
+        --region "${VERACODE_REGION}" \
+        --timeout 55 \
+        --export-results assessment-results.json \
+        --break
+  artifacts:
+    paths:
+      - assessment-results.json
+    when: always         # preserve results even on policy failure (exit 4)
+    expire_in: 30 days
+  needs:
+    - job: verascan_upload
+      artifacts: true   # makes vid.env available in this job's workspace
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_MERGE_REQUEST_IID

--- a/verascan/src/assessment.rs
+++ b/verascan/src/assessment.rs
@@ -1576,6 +1576,7 @@ impl AssessmentSubmitter {
         }
 
         let policy_api = self.client.policy_api();
+        let timeout_minutes = self.config.timeout;
         let poll_interval = 30u32; // 30-second intervals for policy evaluation
         let remaining_secs = deadline
             .saturating_duration_since(std::time::Instant::now())
@@ -1616,6 +1617,16 @@ impl AssessmentSubmitter {
                     return Err(AssessmentError::AuthError(format!(
                         "Authentication error during policy evaluation: {e}"
                     )));
+                }
+                if matches!(e, veracode_platform::policy::PolicyError::Timeout) {
+                    let msg = format!(
+                        "Policy evaluation phase timed out after {timeout_minutes} minutes"
+                    );
+                    return if self.config.soft_timeout {
+                        Err(AssessmentError::ScanStillInProgress(msg))
+                    } else {
+                        Err(AssessmentError::ScanError(msg))
+                    };
                 }
                 Err(AssessmentError::ScanError(format!(
                     "Policy evaluation phase failed: {e}"

--- a/verascan/src/assessment.rs
+++ b/verascan/src/assessment.rs
@@ -154,6 +154,8 @@ pub enum AssessmentError {
     ValidationError(ValidationError),
     /// Authentication/authorization error (401/403) — credentials may have expired
     AuthError(String),
+    /// Scan is still in progress after the configured timeout — safe to retry (exit code 75)
+    ScanStillInProgress(String),
 }
 
 impl std::fmt::Display for AssessmentError {
@@ -168,6 +170,9 @@ impl std::fmt::Display for AssessmentError {
             AssessmentError::PolicyError(msg) => write!(f, "Policy error: {msg}"),
             AssessmentError::ValidationError(e) => write!(f, "File validation error: {e}"),
             AssessmentError::AuthError(msg) => write!(f, "Authentication error: {msg}"),
+            AssessmentError::ScanStillInProgress(msg) => {
+                write!(f, "Scan still in progress (timeout): {msg}")
+            }
         }
     }
 }
@@ -192,7 +197,8 @@ pub fn is_auth_error(error: &AssessmentError) -> bool {
         | AssessmentError::UploadError(_)
         | AssessmentError::SandboxError(_)
         | AssessmentError::PolicyError(_)
-        | AssessmentError::ValidationError(_) => false,
+        | AssessmentError::ValidationError(_)
+        | AssessmentError::ScanStillInProgress(_) => false,
     }
 }
 
@@ -249,6 +255,9 @@ pub struct AssessmentScanConfig {
     pub strict_sandbox: bool,
     /// Custom build version (if None, auto-generates timestamp)
     pub build_version: Option<String>,
+    /// When true, timeout returns `ScanStillInProgress` (exit 75) instead of `ScanError` (exit 1).
+    /// Used by the `monitor` subcommand so GitLab CI can retry the job on timeout.
+    pub soft_timeout: bool,
 }
 
 impl Default for AssessmentScanConfig {
@@ -271,6 +280,7 @@ impl Default for AssessmentScanConfig {
             force_buildinfo_api: false, // Default to trying summary report first
             strict_sandbox: false,   // Default to not treating Conditional Pass as failure
             build_version: None,     // Default to auto-generated timestamp
+            soft_timeout: false,     // Default to hard timeout (ScanError, exit 1)
         }
     }
 }
@@ -634,7 +644,8 @@ impl AssessmentSubmitter {
                             | AssessmentError::ScanError(msg)
                             | AssessmentError::SandboxError(msg)
                             | AssessmentError::PolicyError(msg)
-                            | AssessmentError::AuthError(msg) => msg.clone(),
+                            | AssessmentError::AuthError(msg)
+                            | AssessmentError::ScanStillInProgress(msg) => msg.clone(),
                             AssessmentError::ValidationError(err) => format!("{err}"),
                         };
                         warn!(
@@ -1048,6 +1059,7 @@ impl AssessmentSubmitter {
         app_id: &ApplicationId,
         build_id: &BuildId,
         sandbox_id: Option<&SandboxId>,
+        deadline: std::time::Instant,
     ) -> Result<(), AssessmentError> {
         if !self.config.monitor_completion {
             info!(
@@ -1059,16 +1071,16 @@ impl AssessmentSubmitter {
 
         if !self.is_autoscan_enabled() {
             debug!("🔄 Autoscan disabled, will manually start scan after prescan completes");
-            self.monitor_prescan_phase(app_id.for_xml_api(), build_id, sandbox_id)
+            self.monitor_prescan_phase(app_id.for_xml_api(), build_id, sandbox_id, deadline)
                 .await?;
             debug!("🔄 Prescan complete, manually starting scan...");
             self.start_scan(app_id.for_xml_api(), build_id, sandbox_id)
                 .await?;
-            self.monitor_build_phase(app_id.for_xml_api(), build_id, sandbox_id)
+            self.monitor_build_phase(app_id.for_xml_api(), build_id, sandbox_id, deadline)
                 .await?;
         } else {
             debug!("🤖 Autoscan enabled, scan will start automatically after prescan");
-            self.monitor_scan_progress(app_id.for_xml_api(), build_id, sandbox_id)
+            self.monitor_scan_progress(app_id.for_xml_api(), build_id, sandbox_id, deadline)
                 .await?;
         }
 
@@ -1077,7 +1089,7 @@ impl AssessmentSubmitter {
 
         if force_buildinfo {
             info!("🔄 XML API mode detected - adding policy evaluation phase");
-            self.monitor_policy_evaluation(app_id.for_xml_api(), sandbox_id)
+            self.monitor_policy_evaluation(app_id.for_xml_api(), sandbox_id, deadline)
                 .await?;
         } else {
             info!("📊 Summary report mode - policy evaluation handled during export");
@@ -1108,7 +1120,12 @@ impl AssessmentSubmitter {
             return Ok(build_id);
         }
 
-        self.run_monitoring_and_export(app_id, &build_id, sandbox_id.as_ref())
+        let deadline = std::time::Instant::now()
+            .checked_add(std::time::Duration::from_secs(
+                u64::from(self.config.timeout).saturating_mul(60),
+            ))
+            .unwrap_or_else(std::time::Instant::now);
+        self.run_monitoring_and_export(app_id, &build_id, sandbox_id.as_ref(), deadline)
             .await?;
 
         Ok(build_id)
@@ -1304,6 +1321,7 @@ impl AssessmentSubmitter {
         app_id: &str,
         build_id: &BuildId,
         sandbox_id: Option<&SandboxId>,
+        deadline: std::time::Instant,
     ) -> Result<(), AssessmentError> {
         {
             info!("🔍 Starting two-phase scan monitoring (Java-compatible approach)");
@@ -1314,7 +1332,7 @@ impl AssessmentSubmitter {
 
         // Phase 1: Monitor prescan status until "Pre-Scan Success" or failure
         match self
-            .monitor_prescan_phase(app_id, build_id, sandbox_id)
+            .monitor_prescan_phase(app_id, build_id, sandbox_id, deadline)
             .await
         {
             Ok(()) => {
@@ -1324,7 +1342,10 @@ impl AssessmentSubmitter {
         }
 
         // Phase 2: Monitor build status until "Results Ready" or failure
-        match self.monitor_build_phase(app_id, build_id, sandbox_id).await {
+        match self
+            .monitor_build_phase(app_id, build_id, sandbox_id, deadline)
+            .await
+        {
             Ok(()) => {
                 {
                     info!("✅ Phase 2 complete - scan finished successfully");
@@ -1341,6 +1362,7 @@ impl AssessmentSubmitter {
         app_id: &str,
         build_id: &BuildId,
         sandbox_id: Option<&SandboxId>,
+        deadline: std::time::Instant,
     ) -> Result<(), AssessmentError> {
         {
             info!("🔄 Phase 1: Monitoring prescan status...");
@@ -1348,8 +1370,14 @@ impl AssessmentSubmitter {
 
         let scan_api = self.client.scan_api()?;
         let timeout_minutes = self.config.timeout;
-        let poll_interval = 30; // Java uses 30-second intervals for prescan
-        let max_polls = timeout_minutes.saturating_mul(60) / poll_interval;
+        let poll_interval = 30u32; // Java uses 30-second intervals for prescan
+        let remaining_secs = deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .as_secs();
+        let max_polls = remaining_secs
+            .checked_div(u64::from(poll_interval))
+            .and_then(|v| u32::try_from(v).ok())
+            .unwrap_or(u32::MAX);
 
         for poll_count in 1..=max_polls {
             info!("🔄 Prescan poll attempt {poll_count}/{max_polls}");
@@ -1405,9 +1433,15 @@ impl AssessmentSubmitter {
             }
         }
 
-        Err(AssessmentError::ScanError(format!(
-            "Prescan phase timed out after {timeout_minutes} minutes"
-        )))
+        if self.config.soft_timeout {
+            Err(AssessmentError::ScanStillInProgress(format!(
+                "Prescan phase timed out after {timeout_minutes} minutes"
+            )))
+        } else {
+            Err(AssessmentError::ScanError(format!(
+                "Prescan phase timed out after {timeout_minutes} minutes"
+            )))
+        }
     }
 
     /// Phase 2: Monitor build status (Java getbuildinfo.do API)
@@ -1416,6 +1450,7 @@ impl AssessmentSubmitter {
         app_id: &str,
         build_id: &BuildId,
         sandbox_id: Option<&SandboxId>,
+        deadline: std::time::Instant,
     ) -> Result<(), AssessmentError> {
         {
             info!("🔄 Phase 2: Monitoring build status...");
@@ -1423,8 +1458,14 @@ impl AssessmentSubmitter {
 
         let scan_api = self.client.scan_api()?;
         let timeout_minutes = self.config.timeout;
-        let poll_interval = 60; // Java uses 60-second intervals for build monitoring
-        let max_polls = timeout_minutes.saturating_mul(60) / poll_interval;
+        let poll_interval = 60u32; // Java uses 60-second intervals for build monitoring
+        let remaining_secs = deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .as_secs();
+        let max_polls = remaining_secs
+            .checked_div(u64::from(poll_interval))
+            .and_then(|v| u32::try_from(v).ok())
+            .unwrap_or(u32::MAX);
 
         for poll_count in 1..=max_polls {
             info!("🔄 Build status poll attempt {poll_count}/{max_polls}");
@@ -1506,9 +1547,15 @@ impl AssessmentSubmitter {
             }
         }
 
-        Err(AssessmentError::ScanError(format!(
-            "Build monitoring phase timed out after {timeout_minutes} minutes"
-        )))
+        if self.config.soft_timeout {
+            Err(AssessmentError::ScanStillInProgress(format!(
+                "Build monitoring phase timed out after {timeout_minutes} minutes"
+            )))
+        } else {
+            Err(AssessmentError::ScanError(format!(
+                "Build monitoring phase timed out after {timeout_minutes} minutes"
+            )))
+        }
     }
 
     /// Phase 3: Monitor policy evaluation until ready (XML API only)
@@ -1522,15 +1569,21 @@ impl AssessmentSubmitter {
         &self,
         app_id: &str,
         sandbox_id: Option<&SandboxId>,
+        deadline: std::time::Instant,
     ) -> Result<(), AssessmentError> {
         {
             info!("🔄 Phase 3: Monitoring policy evaluation...");
         }
 
         let policy_api = self.client.policy_api();
-        let timeout_minutes = self.config.timeout;
-        let poll_interval = 30; // 30-second intervals for policy evaluation
-        let max_retries = timeout_minutes.saturating_mul(60) / poll_interval;
+        let poll_interval = 30u32; // 30-second intervals for policy evaluation
+        let remaining_secs = deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .as_secs();
+        let max_retries = remaining_secs
+            .checked_div(u64::from(poll_interval))
+            .and_then(|v| u32::try_from(v).ok())
+            .unwrap_or(u32::MAX);
 
         let sandbox_legacy_id = match self.config.scan_type {
             ScanType::Sandbox => sandbox_id.map(|s| s.for_xml_api()),
@@ -1887,6 +1940,7 @@ mod tests {
             force_buildinfo_api: false,         // Test default value
             strict_sandbox: false,              // Test default value
             build_version: Some("v1.2.3".to_string()), // Test custom build version
+            soft_timeout: false,                // Test default value
         };
 
         assert_eq!(config.threads, 8);

--- a/verascan/src/baseline.rs
+++ b/verascan/src/baseline.rs
@@ -745,7 +745,7 @@ impl BaselineManager {
         }
 
         let mut cwe_vec: Vec<(String, u32)> = cwe_counts.into_iter().collect();
-        cwe_vec.sort_by(|a, b| b.1.cmp(&a.1));
+        cwe_vec.sort_by_key(|b| std::cmp::Reverse(b.1));
         let new_cwe_breakdown: Vec<String> = cwe_vec
             .into_iter()
             .take(5)
@@ -1160,7 +1160,7 @@ impl BaselineManager {
         }
 
         let mut cwe_vec: Vec<(String, u32)> = cwe_counts.into_iter().collect();
-        cwe_vec.sort_by(|a, b| b.1.cmp(&a.1));
+        cwe_vec.sort_by_key(|b| std::cmp::Reverse(b.1));
         let violation_cwe_breakdown: Vec<String> = cwe_vec
             .into_iter()
             .take(5)

--- a/verascan/src/cli.rs
+++ b/verascan/src/cli.rs
@@ -269,6 +269,15 @@ pub enum Commands {
         )]
         no_wait: bool,
 
+        /// File to write `VERASCAN_BUILD_ID` when using --no-wait (for CI artifact passing)
+        #[arg(
+            long = "build-id-file",
+            help = "File to write VERASCAN_BUILD_ID=\"<id>\" when using --no-wait (default: vid.env)",
+            default_value = "vid.env",
+            value_parser = validate_build_id_file
+        )]
+        build_id_file: String,
+
         /// Delete incomplete scan policy for assessment scans
         #[arg(long = "deleteincompletescan", help = "Build deletion policy for assessment scans: 0=Never delete, 1=Delete safe builds only (default), 2=Delete any build except Results Ready", default_value = "1", value_parser = validate_delete_incomplete_scan)]
         deleteincompletescan: u8,
@@ -339,6 +348,65 @@ pub enum Commands {
         min_severity: Option<String>,
     },
 
+    /// Monitor an in-progress Veracode Assessment scan and evaluate policy on completion
+    Monitor {
+        /// Veracode application profile name
+        #[arg(short = 'n', long = "app-profile-name", help = "Veracode application profile name (required)", value_parser = validate_name_field, required = true)]
+        app_profile_name: String,
+
+        /// Build ID from a previous --no-wait assessment scan
+        #[arg(
+            long = "build-id",
+            help = "Build ID from a previous --no-wait assessment scan (required)",
+            env = "VERASCAN_BUILD_ID",
+            required = true,
+            value_parser = validate_build_id
+        )]
+        build_id: String,
+
+        /// Sandbox name (required if the original scan targeted a sandbox)
+        #[arg(long = "sandbox-name", help = "Sandbox name (required if the original scan targeted a sandbox)", value_parser = validate_sandbox_name)]
+        sandbox_name: Option<String>,
+
+        /// Maximum minutes to monitor before exiting with code 75 (scan still in progress, safe to retry)
+        #[arg(
+            short = 't',
+            long = "timeout",
+            help = "Maximum minutes to monitor before exiting with code 75 (scan still in progress — safe to retry)",
+            default_value = "55"
+        )]
+        timeout: u32,
+
+        /// Export scan results to a file when the scan completes
+        #[arg(
+            long = "export-results",
+            help = "Export assessment scan results to specified file path (JSON format)",
+            default_value = "assessment-results.json"
+        )]
+        export_results: String,
+
+        /// Break build on Veracode platform policy compliance failure
+        #[arg(
+            long = "break",
+            help = "Break build (exit code 4) based on Veracode platform policy compliance"
+        )]
+        break_build: bool,
+
+        /// Force use of getbuildinfo.do XML API for policy evaluation
+        #[arg(
+            long = "force-buildinfo-api",
+            help = "Skip summary report API and use getbuildinfo.do XML API for break build evaluation"
+        )]
+        force_buildinfo_api: bool,
+
+        /// Break build on sandbox Conditional Pass
+        #[arg(
+            long = "strict-sandbox",
+            help = "Exit with code 4 when sandbox scans return 'Conditional Pass'"
+        )]
+        strict_sandbox: bool,
+    },
+
     /// Show all supported environment variables
     HelpEnv,
 }
@@ -377,6 +445,9 @@ impl Args {
             }
             Commands::Export { .. } => {
                 // Export validation happens at the field level with required fields
+            }
+            Commands::Monitor { .. } => {
+                // Monitor validation happens at the field level with required fields
             }
             Commands::HelpEnv => {
                 // No validation needed for help-env subcommand
@@ -484,9 +555,9 @@ fn validate_threads(s: &str) -> Result<usize, String> {
 /// Validate name fields (project name, app profile name)
 fn validate_name_field(s: &str) -> Result<String, String> {
     // Check length
-    if s.len() > 70 {
+    if s.len() > 256 {
         return Err(format!(
-            "Name must be 70 characters or less, got: {} characters",
+            "Name must be 256 characters or less, got: {} characters",
             s.len()
         ));
     }
@@ -912,6 +983,107 @@ fn validate_cmek_alias(s: &str) -> Result<String, String> {
     Ok(s.to_string())
 }
 
+/// Validate build ID input for `--build-id` / `VERASCAN_BUILD_ID`.
+///
+/// Accepts either:
+/// - A positive non-zero integer (Veracode XML API build ID, e.g. `"12345678"`)
+/// - A standard UUID/GUID (e.g. `"550e8400-e29b-41d4-a716-446655440000"`)
+fn validate_build_id(s: &str) -> Result<String, String> {
+    if s.is_empty() {
+        return Err("Build ID cannot be empty".to_string());
+    }
+
+    // Reject control / non-printable characters
+    if s.chars().any(|c| c.is_control()) {
+        return Err("Build ID must not contain control or non-printable characters".to_string());
+    }
+
+    // Accept a positive non-zero integer
+    if s.chars().all(|c| c.is_ascii_digit()) {
+        return match s.parse::<u64>() {
+            Ok(0) => Err("Build ID must be a non-zero value".to_string()),
+            Ok(_) => Ok(s.to_string()),
+            Err(_) => Err(format!("Build ID numeric value is out of range: '{s}'")),
+        };
+    }
+
+    // Accept a UUID/GUID: 8-4-4-4-12 lowercase or uppercase hex digits with hyphens
+    let is_uuid = s.len() == 36
+        && s.bytes().enumerate().all(|(i, c)| {
+            if matches!(i, 8 | 13 | 18 | 23) {
+                c == b'-'
+            } else {
+                c.is_ascii_hexdigit()
+            }
+        });
+
+    if is_uuid {
+        return Ok(s.to_lowercase());
+    }
+
+    Err(format!(
+        "Build ID must be a positive integer or a UUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx), got: '{s}'"
+    ))
+}
+
+/// Validate build ID output file path for `--build-id-file`.
+///
+/// Enforces:
+/// - Valid UTF-8 with no control/non-printable characters
+/// - Maximum 255 characters (common filesystem limit)
+/// - No absolute paths (must not start with `/`)
+/// - No path traversal components (`..`)
+/// - Only safe filename characters: alphanumeric, `-`, `_`, `.`, `/`
+fn validate_build_id_file(s: &str) -> Result<String, String> {
+    // Encoding: reject any non-printable or control characters (UTF-8 is guaranteed by &str)
+    if s.chars().any(|c| c.is_control()) {
+        return Err(
+            "Build ID file path must not contain control or non-printable characters".to_string(),
+        );
+    }
+
+    // Length
+    if s.is_empty() {
+        return Err("Build ID file path cannot be empty".to_string());
+    }
+    if s.len() > 255 {
+        return Err(format!(
+            "Build ID file path must be 255 characters or less, got: {} characters",
+            s.len()
+        ));
+    }
+
+    // Reject absolute paths
+    if s.starts_with('/') {
+        return Err(format!(
+            "Build ID file path must be relative to the working directory, got absolute path: '{s}'"
+        ));
+    }
+
+    // Reject path traversal: any component equal to `..`
+    if std::path::Path::new(s)
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
+    {
+        return Err(format!(
+            "Build ID file path must not contain path traversal sequences (e.g. '../'): '{s}'"
+        ));
+    }
+
+    // Safe character allowlist: alphanumeric, dash, underscore, dot, forward slash
+    let is_valid = s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/'));
+
+    if !is_valid {
+        return Err(format!(
+            "Build ID file path can only contain alphanumeric characters, dashes (-), underscores (_), dots (.), and forward slashes (/). Got: '{s}'"
+        ));
+    }
+
+    Ok(s.to_string())
+}
+
 /// Parse business criticality string to `BusinessCriticality` enum
 #[must_use]
 pub fn parse_business_criticality(
@@ -1149,6 +1321,7 @@ mod tests {
                 sandbox_name: None,
                 modules: None,
                 no_wait: false,
+                build_id_file: "vid.env".to_string(),
                 teamname: None,
                 bus_cri: "very-high".to_string(),
                 repo_url: None,
@@ -1617,7 +1790,7 @@ mod tests {
         // --------------------------------------------------------------------
         // Security concern: Name fields are used in API calls and must be sanitized
         // Property 1: Never panics on valid character sets
-        // Property 2: Length limit (70 chars) is enforced
+        // Property 2: Length limit (256 chars) is enforced
         // Property 3: Empty/whitespace-only strings are rejected
         // Property 4: Valid characters (alphanumeric, -, _, space, /) are accepted
         #[test]
@@ -1629,8 +1802,8 @@ mod tests {
             // Property 1: Never panics (implicit - test completes)
 
             // Property 2: Check length enforcement
-            if input.len() > 70 {
-                assert!(result.is_err(), "Strings over 70 chars should be rejected");
+            if input.len() > 256 {
+                assert!(result.is_err(), "Strings over 256 chars should be rejected");
             }
             // Property 3: Check empty/whitespace rejection
             else if input.trim().is_empty() {
@@ -1823,6 +1996,215 @@ mod tests {
             // Property 4: Result should contain original input
             assert_eq!(result.unwrap(), input);
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // validate_build_id
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_build_id_valid_integer() {
+        assert!(validate_build_id("12345678").is_ok());
+        assert!(validate_build_id("1").is_ok());
+        assert!(validate_build_id("99999999").is_ok());
+    }
+
+    #[test]
+    fn test_validate_build_id_valid_uuid() {
+        // Lowercase
+        assert!(validate_build_id("550e8400-e29b-41d4-a716-446655440000").is_ok());
+        // Uppercase — normalised to lowercase on return
+        let result = validate_build_id("550E8400-E29B-41D4-A716-446655440000");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "550e8400-e29b-41d4-a716-446655440000");
+        // Mixed case
+        assert!(validate_build_id("550e8400-E29B-41d4-A716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn test_validate_build_id_rejects_empty() {
+        let result = validate_build_id("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_build_id_rejects_zero() {
+        let result = validate_build_id("0");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("non-zero"));
+    }
+
+    #[test]
+    fn test_validate_build_id_rejects_control_characters() {
+        let result = validate_build_id("12345\x00678");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("control"));
+
+        let result = validate_build_id("12345\n678");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("control"));
+    }
+
+    #[test]
+    fn test_validate_build_id_rejects_arbitrary_strings() {
+        // Plain text
+        let result = validate_build_id("my-build");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("positive integer or a UUID"));
+
+        // Looks numeric but has letters
+        let result = validate_build_id("1234abc");
+        assert!(result.is_err());
+
+        // UUID wrong length
+        let result = validate_build_id("550e8400-e29b-41d4-a716-44665544000");
+        assert!(result.is_err());
+
+        // UUID wrong structure (missing hyphens)
+        let result = validate_build_id("550e8400e29b41d4a716446655440000");
+        assert!(result.is_err());
+
+        // UUID with invalid hex chars
+        let result = validate_build_id("550e8400-e29b-41d4-a716-44665544000g");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_build_id_returns_integer_unchanged() {
+        let result = validate_build_id("87654321");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "87654321");
+    }
+
+    // -------------------------------------------------------------------------
+    // validate_build_id_file
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_build_id_file_valid() {
+        // Default value
+        assert!(validate_build_id_file("vid.env").is_ok());
+
+        // Simple filenames
+        assert!(validate_build_id_file("build.env").is_ok());
+        assert!(validate_build_id_file("output.txt").is_ok());
+        assert!(validate_build_id_file("build_id").is_ok());
+        assert!(validate_build_id_file("build-id-123").is_ok());
+
+        // Relative subdirectory paths
+        assert!(validate_build_id_file("ci/artifacts/vid.env").is_ok());
+        assert!(validate_build_id_file("output/build.env").is_ok());
+
+        // Dots in filename (not traversal)
+        assert!(validate_build_id_file("my.build.env").is_ok());
+    }
+
+    #[test]
+    fn test_validate_build_id_file_rejects_empty() {
+        let result = validate_build_id_file("");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_build_id_file_rejects_too_long() {
+        let long_path = "a".repeat(256);
+        let result = validate_build_id_file(&long_path);
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("255 characters or less"));
+    }
+
+    #[test]
+    fn test_validate_build_id_file_rejects_absolute_paths() {
+        let result = validate_build_id_file("/etc/passwd");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("relative"));
+
+        let result = validate_build_id_file("/tmp/vid.env");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("relative"));
+    }
+
+    #[test]
+    fn test_validate_build_id_file_rejects_path_traversal() {
+        // Simple traversal
+        let result = validate_build_id_file("../vid.env");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("path traversal"));
+
+        // Nested traversal
+        let result = validate_build_id_file("../../etc/passwd");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("path traversal"));
+
+        // Traversal in the middle of a path
+        let result = validate_build_id_file("ci/../../../etc/passwd");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("path traversal"));
+    }
+
+    #[test]
+    fn test_validate_build_id_file_rejects_control_characters() {
+        // Null byte
+        let result = validate_build_id_file("vid\0.env");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("control"));
+
+        // Newline
+        let result = validate_build_id_file("vid\n.env");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("control"));
+
+        // Tab
+        let result = validate_build_id_file("vid\t.env");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("control"));
+    }
+
+    #[test]
+    fn test_validate_build_id_file_rejects_invalid_characters() {
+        // Space
+        let result = validate_build_id_file("my file.env");
+        assert!(result.is_err());
+        let e = result.unwrap_err();
+        assert!(e.contains("can only contain"));
+
+        // Shell metacharacters
+        let result = validate_build_id_file("vid;env");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("can only contain"));
+
+        let result = validate_build_id_file("$(vid.env)");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("can only contain"));
+
+        let result = validate_build_id_file("vid&.env");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("can only contain"));
+
+        // At-sign
+        let result = validate_build_id_file("vid@.env");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("can only contain"));
+    }
+
+    #[test]
+    fn test_validate_build_id_file_returns_input_unchanged() {
+        let input = "ci/artifacts/vid.env";
+        let result = validate_build_id_file(input);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), input);
     }
 }
 

--- a/verascan/src/export.rs
+++ b/verascan/src/export.rs
@@ -486,7 +486,7 @@ impl ExportWorkflow {
                 }
             }
             let mut cwe_vec: Vec<_> = cwe_counts.into_iter().collect();
-            cwe_vec.sort_by(|a, b| b.1.cmp(&a.1));
+            cwe_vec.sort_by_key(|b| std::cmp::Reverse(b.1));
             cwe_vec
                 .into_iter()
                 .take(10)

--- a/verascan/src/findings.rs
+++ b/verascan/src/findings.rs
@@ -351,7 +351,7 @@ impl FindingsAggregator {
 
         // Get top 5 CWE IDs
         let mut cwe_vec: Vec<(String, u32)> = cwe_counts.into_iter().collect();
-        cwe_vec.sort_by(|a, b| b.1.cmp(&a.1));
+        cwe_vec.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         let total_findings = u32::try_from(findings.len()).unwrap_or(u32::MAX);
         let top_cwe_ids: Vec<CweStatistic> = cwe_vec

--- a/verascan/src/lib.rs
+++ b/verascan/src/lib.rs
@@ -62,7 +62,7 @@ pub use http_client::{
 pub use path_resolver::{PathResolver, PathResolverConfig};
 pub use pipeline::{PipelineError, PipelineScanConfig, PipelineSubmitter};
 pub use policy::execute_policy_download;
-pub use scan::{execute_assessment_scan, execute_pipeline_scan};
+pub use scan::{execute_assessment_scan, execute_monitor_scan, execute_pipeline_scan};
 pub use vault_client::{
     VaultCredentialClient, load_credentials_and_proxy_from_vault, load_vault_config_from_env,
     load_veracode_credentials_with_vault, refresh_credentials_from_vault,

--- a/verascan/src/main.rs
+++ b/verascan/src/main.rs
@@ -4,8 +4,8 @@ use verascan::cli::print_environment_variables;
 use verascan::credentials::load_veracode_credentials_from_env;
 use verascan::{
     Args, Commands, create_veracode_config_from_credentials, create_veracode_config_with_proxy,
-    execute_assessment_scan, execute_file_search, execute_findings_export, execute_pipeline_scan,
-    execute_policy_download, load_credentials_and_proxy_from_vault,
+    execute_assessment_scan, execute_file_search, execute_findings_export, execute_monitor_scan,
+    execute_pipeline_scan, execute_policy_download, load_credentials_and_proxy_from_vault,
 };
 
 fn main() {
@@ -134,6 +134,10 @@ fn main() {
                     .await
                     .unwrap_or_else(|code| std::process::exit(code));
             });
+        }
+        Commands::Monitor { .. } => {
+            execute_monitor_scan(&veracode_config, &args)
+                .unwrap_or_else(|code| std::process::exit(code));
         }
         Commands::HelpEnv => {
             // Already handled above before credential loading

--- a/verascan/src/scan.rs
+++ b/verascan/src/scan.rs
@@ -2148,7 +2148,7 @@ async fn execute_assessment_scan_async(
 
         // Write build ID file when --no-wait is set so downstream CI jobs can consume it
         if *no_wait {
-            let content = format!("VERASCAN_BUILD_ID=\"{build_id}\"\n");
+            let content = format!("export VERASCAN_BUILD_ID=\"{build_id}\"\n");
             match tokio::fs::write(build_id_file, &content).await {
                 Ok(_) => info!("📄 Build ID written to: {build_id_file}"),
                 Err(e) => {

--- a/verascan/src/scan.rs
+++ b/verascan/src/scan.rs
@@ -1768,7 +1768,7 @@ fn calculate_cwe_breakdown(findings: &[FindingWithSource]) -> serde_json::Value 
 
     // Get top 10 CWEs by count
     let mut cwe_vec: Vec<(String, u32)> = breakdown.into_iter().collect();
-    cwe_vec.sort_by(|a, b| b.1.cmp(&a.1));
+    cwe_vec.sort_by_key(|b| std::cmp::Reverse(b.1));
     let top_cwes: std::collections::HashMap<String, u32> = cwe_vec.into_iter().take(10).collect();
 
     serde_json::to_value(top_cwes).unwrap_or(serde_json::Value::Object(serde_json::Map::new()))

--- a/verascan/src/scan.rs
+++ b/verascan/src/scan.rs
@@ -1849,6 +1849,7 @@ pub fn execute_assessment_scan(
             force_buildinfo_api: *force_buildinfo_api, // CLI flag for forcing buildinfo API
             strict_sandbox: *strict_sandbox, // CLI flag for treating Conditional Pass as failure for sandbox scans
             build_version: build_version.clone(), // Custom build version (None = auto-generated)
+            soft_timeout: false,             // assessment command uses hard timeout (exit 1)
         };
 
         let submitter = AssessmentSubmitter::new(veracode_config.clone(), assessment_config)
@@ -1933,6 +1934,8 @@ async fn execute_assessment_scan_async(
         bus_cri,
         repo_url,
         cmek,
+        no_wait,
+        build_id_file,
         ..
     } = &args.command
     {
@@ -2079,12 +2082,23 @@ async fn execute_assessment_scan_async(
         // ── Phase 2: Monitor + export ────────────────────────────────────────
         // On 401/403, refresh credentials and resume monitoring with the same
         // build_id and sandbox_id — the scan keeps running on Veracode's servers.
+        // Deadline is computed once here so credential refreshes don't reset the clock.
         {
+            let monitoring_deadline = std::time::Instant::now()
+                .checked_add(std::time::Duration::from_secs(
+                    u64::from(current_submitter.config.timeout).saturating_mul(60),
+                ))
+                .unwrap_or_else(std::time::Instant::now);
             let mut attempt = 0u32;
             loop {
                 attempt = attempt.saturating_add(1);
                 match current_submitter
-                    .run_monitoring_and_export(&app_id, &build_id, sandbox_id.as_ref())
+                    .run_monitoring_and_export(
+                        &app_id,
+                        &build_id,
+                        sandbox_id.as_ref(),
+                        monitoring_deadline,
+                    )
                     .await
                 {
                     Ok(()) => break,
@@ -2131,9 +2145,283 @@ async fn execute_assessment_scan_async(
                 info!("   Scan Type: Policy");
             }
         }
+
+        // Write build ID file when --no-wait is set so downstream CI jobs can consume it
+        if *no_wait {
+            let content = format!("VERASCAN_BUILD_ID=\"{build_id}\"\n");
+            match tokio::fs::write(build_id_file, &content).await {
+                Ok(_) => info!("📄 Build ID written to: {build_id_file}"),
+                Err(e) => {
+                    error!("❌ Failed to write build ID file '{build_id_file}': {e}");
+                    return Err(1);
+                }
+            }
+        }
+
         Ok(())
     } else {
         error!("❌ execute_assessment_scan_async called with non-assessment command");
+        Err(1)
+    }
+}
+
+/// Execute assessment monitor workflow — reconnect to an in-progress scan by build ID.
+///
+/// Intended for CI pipelines (e.g. GitLab) where the scan was submitted with `--no-wait`
+/// in a previous job. Exit codes:
+///   0  — scan complete, policy passed (or `--break` not set)
+///   4  — scan complete, policy Did Not Pass (with `--break`)
+///   75 — scan still in progress after `--timeout`; safe to retry the job
+///   1  — error (app not found, API failure, prescan failed, etc.)
+///
+/// # Errors
+/// Returns an error code if the application cannot be found, the sandbox lookup fails,
+/// or an unrecoverable API error occurs during monitoring.
+pub fn execute_monitor_scan(veracode_config: &VeracodeConfig, args: &Args) -> Result<(), i32> {
+    if let Commands::Monitor {
+        app_profile_name,
+        build_id,
+        sandbox_name,
+        timeout,
+        export_results,
+        break_build,
+        force_buildinfo_api,
+        strict_sandbox,
+        ..
+    } = &args.command
+    {
+        info!("🔍 Assessment Monitor requested");
+        info!("   App Profile: {app_profile_name}");
+        info!("   Build ID: {build_id}");
+        if let Some(sb) = sandbox_name {
+            info!("   Sandbox: {sb}");
+        }
+        info!("   Timeout: {timeout} minutes");
+
+        let region = parse_region(&args.region)?;
+        let scan_type = if sandbox_name.is_some() {
+            ScanType::Sandbox
+        } else {
+            ScanType::Policy
+        };
+
+        let assessment_config = AssessmentScanConfig {
+            app_profile_name: app_profile_name.clone(),
+            scan_type,
+            sandbox_name: sandbox_name.clone(),
+            selected_modules: None,
+            region,
+            timeout: *timeout,
+            threads: 4, // not used during monitoring
+            autoscan: true,
+            monitor_completion: true,
+            export_results_path: export_results.clone(),
+            deleteincompletescan: 1,
+            break_build: *break_build,
+            policy_wait_max_retries: 30,
+            policy_wait_retry_delay_seconds: 10,
+            force_buildinfo_api: *force_buildinfo_api,
+            strict_sandbox: *strict_sandbox,
+            build_version: None,
+            soft_timeout: true, // timeouts exit with code 75 rather than 1
+        };
+
+        let submitter = AssessmentSubmitter::new(veracode_config.clone(), assessment_config)
+            .map_err(|e| {
+                error!("❌ Failed to create assessment monitor: {e}");
+                1
+            })?;
+
+        execute_monitor_scan_with_runtime(submitter, build_id, args)
+    } else {
+        error!("❌ execute_monitor_scan called with non-monitor command");
+        Err(1)
+    }
+}
+
+fn execute_monitor_scan_with_runtime(
+    submitter: AssessmentSubmitter,
+    build_id_str: &str,
+    args: &Args,
+) -> Result<(), i32> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| {
+            error!("❌ Failed to create async runtime: {e}");
+            1
+        })?;
+
+    let build_id_str = build_id_str.to_string();
+    runtime
+        .block_on(async move { execute_monitor_scan_async(submitter, &build_id_str, args).await })
+}
+
+async fn execute_monitor_scan_async(
+    submitter: AssessmentSubmitter,
+    build_id_str: &str,
+    args: &Args,
+) -> Result<(), i32> {
+    if let Commands::Monitor {
+        app_profile_name,
+        sandbox_name,
+        ..
+    } = &args.command
+    {
+        const MAX_ATTEMPTS: u32 = 3;
+        let mut current_submitter = submitter;
+
+        // Look up application by name (read-only — never creates)
+        let app = {
+            let mut attempt = 0u32;
+            loop {
+                attempt = attempt.saturating_add(1);
+                match current_submitter
+                    .client
+                    .get_application_by_name(app_profile_name)
+                    .await
+                {
+                    Ok(Some(app)) => {
+                        info!("✅ Application found: {app_profile_name}");
+                        break app;
+                    }
+                    Ok(None) => {
+                        error!("❌ Application not found: '{app_profile_name}'");
+                        return Err(1);
+                    }
+                    Err(ref e)
+                        if matches!(
+                            e,
+                            veracode_platform::VeracodeError::Authentication(_)
+                                | veracode_platform::VeracodeError::HttpStatus {
+                                    status_code: 401 | 403,
+                                    ..
+                                }
+                        ) && attempt < MAX_ATTEMPTS =>
+                    {
+                        warn!(
+                            "⚠️  Authentication error looking up application \
+                             (attempt {attempt}/{MAX_ATTEMPTS}), refreshing credentials..."
+                        );
+                        match try_refresh_assessment_submitter(
+                            &args.region,
+                            &current_submitter.config,
+                        )
+                        .await
+                        {
+                            Some((new_sub, _)) => current_submitter = new_sub,
+                            None => return Err(1),
+                        }
+                    }
+                    Err(e) => {
+                        error!("❌ Failed to look up application '{app_profile_name}': {e}");
+                        return Err(1);
+                    }
+                }
+            }
+        };
+
+        let app_id = crate::assessment::ApplicationId::new(app.guid, app.id.to_string());
+
+        // Look up sandbox by name if this was a sandbox scan
+        let sandbox_id = if let Some(sandbox_name_str) = sandbox_name {
+            let result = {
+                let sandbox_api = current_submitter.client.sandbox_api();
+                sandbox_api
+                    .get_sandbox_by_name(app_id.for_rest_api(), sandbox_name_str)
+                    .await
+            };
+            match result {
+                Ok(Some(sandbox)) => {
+                    info!("✅ Sandbox found: {sandbox_name_str}");
+                    let legacy_id = sandbox.id.map(|id| id.to_string()).unwrap_or_default();
+                    Some(crate::assessment::SandboxId::new(
+                        sandbox.guid,
+                        legacy_id,
+                        sandbox_name_str.clone(),
+                    ))
+                }
+                Ok(None) => {
+                    error!("❌ Sandbox not found: '{sandbox_name_str}'");
+                    return Err(1);
+                }
+                Err(e) => {
+                    error!("❌ Failed to look up sandbox '{sandbox_name_str}': {e}");
+                    return Err(1);
+                }
+            }
+        } else {
+            None
+        };
+
+        let build_id = crate::assessment::BuildId::new(build_id_str.to_string());
+
+        info!("🔍 Starting monitor for build ID: {}", build_id.id());
+
+        // Monitor with Vault credential refresh on auth errors — same pattern as assessment command.
+        // Deadline is computed once here so credential refreshes don't reset the clock.
+        let monitoring_deadline = std::time::Instant::now()
+            .checked_add(std::time::Duration::from_secs(
+                u64::from(current_submitter.config.timeout).saturating_mul(60),
+            ))
+            .unwrap_or_else(std::time::Instant::now);
+        let mut attempt = 0u32;
+        loop {
+            attempt = attempt.saturating_add(1);
+            match current_submitter
+                .run_monitoring_and_export(
+                    &app_id,
+                    &build_id,
+                    sandbox_id.as_ref(),
+                    monitoring_deadline,
+                )
+                .await
+            {
+                Ok(()) => break,
+                Err(crate::assessment::AssessmentError::ScanStillInProgress(_)) => {
+                    info!(
+                        "⏳ Scan still in progress after {} minutes — exiting with code 75 (safe to retry)",
+                        current_submitter.config.timeout
+                    );
+                    info!(
+                        "   Rerun: verascan monitor --app-profile-name \"{}\" --build-id {}",
+                        app_profile_name,
+                        build_id.id()
+                    );
+                    std::process::exit(75);
+                }
+                Err(ref e) if crate::assessment::is_auth_error(e) && attempt < MAX_ATTEMPTS => {
+                    warn!(
+                        "⚠️  Authentication error during monitoring \
+                         (attempt {attempt}/{MAX_ATTEMPTS}), refreshing credentials from Vault..."
+                    );
+                    match try_refresh_assessment_submitter(&args.region, &current_submitter.config)
+                        .await
+                    {
+                        Some((new_sub, _)) => {
+                            info!(
+                                "✅ Credentials refreshed, resuming monitoring with same \
+                                 build ID (attempt {}/{MAX_ATTEMPTS})...",
+                                attempt.saturating_add(1)
+                            );
+                            current_submitter = new_sub;
+                        }
+                        None => return Err(1),
+                    }
+                }
+                Err(e) => {
+                    error!("❌ Monitor failed: {e}");
+                    return Err(1);
+                }
+            }
+        }
+
+        info!("✅ Monitor completed");
+        info!("   Build ID: {}", build_id.id());
+        info!("   App Profile: {app_profile_name}");
+        Ok(())
+    } else {
+        error!("❌ execute_monitor_scan_async called with non-monitor command");
         Err(1)
     }
 }

--- a/verascan/src/search.rs
+++ b/verascan/src/search.rs
@@ -29,6 +29,9 @@ pub fn execute_file_search(args: &Args) -> Result<Vec<PathBuf>, i32> {
         Commands::Export { .. } => {
             return Err(1); // Export command doesn't need file search
         }
+        Commands::Monitor { .. } => {
+            return Err(1); // Monitor command doesn't need file search
+        }
         Commands::HelpEnv => {
             return Err(1); // HelpEnv command doesn't need file search
         }
@@ -87,6 +90,10 @@ fn display_search_results(
             }
             Commands::Export { .. } => {
                 // Export command doesn't use file search, this shouldn't be reached
+                return Ok(());
+            }
+            Commands::Monitor { .. } => {
+                // Monitor command doesn't use file search, this shouldn't be reached
                 return Ok(());
             }
             Commands::HelpEnv => {


### PR DESCRIPTION
## Summary

- **New `verascan monitor` subcommand**: Reconnects to an in-progress assessment scan by build ID, designed for multi-job CI pipelines (e.g. GitLab) where upload and monitoring run as separate jobs
  - Accepts `--app-profile-name`, `--build-id` (or `VERASCAN_BUILD_ID` env var), optional `--sandbox-name`, `--timeout`, `--export-results`, `--break`, `--force-buildinfo-api`, `--strict-sandbox`
  - Exit codes: `0` (pass), `4` (policy DNP with `--break`), `75` (still in progress / safe to retry), `1` (error)
- **`--build-id-file` flag for `assessment --no-wait`**: Writes `VERASCAN_BUILD_ID="<id>"` to a file (default: `vid.env`) for CI artifact passing between jobs; `monitor` reads the env var automatically
- **Timeout deadline fix**: Monitoring deadline is now anchored to a single `Instant` before the auth-retry loop, so Vault credential rotation mid-poll no longer resets the timeout clock — applies to both `assessment` and `monitor` subcommands
- **Name field length limit raised**: `--app-profile-name` and other name fields now accept up to 256 characters (was 70)
- **GitLab CI two-job example** added at `verascan/examples/gitlab_ci_assessment_monitor.yml`

## Test plan

- [x] `verascan assessment --no-wait --build-id-file vid.env ...` writes `VERASCAN_BUILD_ID="<id>"` to `vid.env`
- [x] `verascan monitor --app-profile-name <name>` with `VERASCAN_BUILD_ID` env var set polls and exits with correct codes (0 / 4 / 75 / 1)
- [x] `verascan monitor --build-id <id> --app-profile-name <name>` works without the env var
- [x] Mid-poll Vault credential rotation no longer resets the timeout clock for both `assessment` and `monitor`
- [x] App profile names longer than 70 characters are accepted without validation errors
- [x] GitLab CI example `.yml` is syntactically valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)