### PR TITLE
feat: Add Vault User-Agent header to all CLIs (veraaudit v0.6.1 / veracmek v0.5.16 / verascan v0.7.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "veraaudit"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3637,6 +3637,8 @@ dependencies = [
  "futures",
  "log",
  "regex",
+ "reqwest",
+ "rustify",
  "secrecy",
  "serde",
  "serde_json",
@@ -3651,13 +3653,15 @@ dependencies = [
 
 [[package]]
 name = "veracmek"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "backon",
  "clap",
  "env_logger",
  "log",
+ "reqwest",
+ "rustify",
  "secrecy",
  "serde",
  "serde_json",
@@ -3700,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "verascan"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "backon",
  "chrono",
@@ -3713,6 +3717,7 @@ dependencies = [
  "proptest",
  "regex",
  "reqwest",
+ "rustify",
  "secrecy",
  "serde",
  "serde_json",

--- a/veraaudit/CHANGELOG.md
+++ b/veraaudit/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the veraaudit project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-05-30
+
+### Changed
+- **Vault `User-Agent` header**: all HTTP requests to HashiCorp Vault now identify as `veraaudit/<version>` (e.g. `veraaudit/0.6.1`), covering authentication, secret retrieval, and token revocation. This makes Vault audit logs and server-side access logs immediately attributable to veraaudit without requiring additional configuration
+  - **Modified Files**: `Cargo.toml`, `src/vault_client.rs`
+
 ## [0.6.0] - 2026-05-30
 
 ### Added

--- a/veraaudit/Cargo.toml
+++ b/veraaudit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veraaudit"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "CLI tool for retrieving and archiving Veracode audit logs using the Reporting REST API"
 authors = ["Veracode API Team"]
@@ -60,7 +60,9 @@ secrecy = { version = "0.10", features = ["serde"] }
 anyhow = "1.0"
 
 # Vault client for secure credential management
-vaultrs = "0.8"
+vaultrs = { version = "0.8", features = ["rustls"] }
+rustify = "0.7"
+reqwest = { version = "0.13", features = ["rustls"], default-features = false }
 backon = "1.3"
 url = "2.5"
 

--- a/veraaudit/README.md
+++ b/veraaudit/README.md
@@ -2,7 +2,7 @@
 
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-brightgreen.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Crate Version](https://img.shields.io/badge/version-0.6.0-blue.svg)](Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.6.1-blue.svg)](Cargo.toml)
 
 CLI tool for retrieving and archiving Veracode audit logs using the Reporting REST API.
 
@@ -223,7 +223,7 @@ veraaudit supports two credential methods with automatic fallback:
 
 ### 1. Vault (Priority)
 
-When Vault environment variables are set, credentials are retrieved from Vault:
+When Vault environment variables are set, credentials are retrieved from Vault. All requests to Vault identify as `veraaudit/<version>` via the `User-Agent` header, making Vault audit logs immediately attributable to veraaudit.
 
 ```bash
 export VAULT_CLI_ADDR="https://vault.company.com"

--- a/veraaudit/src/vault_client.rs
+++ b/veraaudit/src/vault_client.rs
@@ -1,6 +1,7 @@
 use crate::credentials::{CredentialError, VaultConfig, validate_api_credential};
 use backon::{ExponentialBuilder, Retryable};
 use log::{debug, error, info, warn};
+use rustify::clients::reqwest::Client as HTTPClient;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
@@ -8,11 +9,14 @@ use std::error::Error;
 use std::time::Duration;
 use url::Url;
 use vaultrs::{
+    api::EndpointMiddleware,
     auth::oidc,
-    client::{Client, VaultClient, VaultClientSettingsBuilder},
+    client::{Client, VaultClient, VaultClientSettings, VaultClientSettingsBuilder},
     error::ClientError,
     kv2, token,
 };
+
+const USER_AGENT: &str = concat!("veraaudit/", env!("CARGO_PKG_VERSION"));
 
 // Character sets for validation
 const SPECIAL_CHARS: &[char] = &[
@@ -475,12 +479,51 @@ fn create_vault_client(config: &VaultConfig) -> Result<VaultClient, CredentialEr
             message: format!("Failed to build vault client settings: {e}"),
         })?;
 
-    let client = VaultClient::new(settings).map_err(|e| CredentialError::VaultAuthError {
-        context: format!("Failed to create vault client: {e}"),
-    })?;
+    let client = build_vault_client(settings)?;
 
     debug!("Vault client created successfully");
     Ok(client)
+}
+
+fn build_vault_client(settings: VaultClientSettings) -> Result<VaultClient, CredentialError> {
+    let mut http_builder = reqwest::ClientBuilder::new()
+        .tls_backend_rustls()
+        .user_agent(USER_AGENT);
+
+    http_builder = http_builder.tls_danger_accept_invalid_certs(!settings.verify);
+
+    for path in &settings.ca_certs {
+        let content = std::fs::read(path).map_err(|e| CredentialError::VaultConfigError {
+            message: format!("Failed to read CA cert {path}: {e}"),
+        })?;
+        let certs = reqwest::Certificate::from_pem_bundle(&content).map_err(|e| {
+            CredentialError::VaultConfigError {
+                message: format!("Failed to parse CA cert {path}: {e}"),
+            }
+        })?;
+        http_builder = http_builder.tls_certs_merge(certs);
+    }
+
+    let version_str = format!("v{}", settings.version);
+    let middle = EndpointMiddleware {
+        token: settings.token.clone(),
+        version: version_str,
+        wrap: None,
+        namespace: settings.namespace.clone(),
+    };
+
+    let reqwest_client = http_builder
+        .build()
+        .map_err(|e| CredentialError::VaultConfigError {
+            message: format!("Failed to build HTTP client: {e}"),
+        })?;
+
+    let http = HTTPClient::new(settings.address.as_str(), reqwest_client);
+    Ok(VaultClient {
+        http,
+        middle,
+        settings,
+    })
 }
 
 /// Authenticate with vault using exponential backoff and proper token management

--- a/veracmek/CHANGELOG.md
+++ b/veracmek/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to veracmek will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.16] - 2026-05-30
+
+### Changed
+- **Vault `User-Agent` header**: all HTTP requests to HashiCorp Vault now identify as `veracmek/<version>` (e.g. `veracmek/0.5.16`), covering authentication, secret retrieval, and token revocation. This makes Vault audit logs and server-side access logs immediately attributable to veracmek without requiring additional configuration
+  - **Modified Files**: `Cargo.toml`, `src/vault_client.rs`
+
 ## [0.5.15] - 2026-05-30
 
 ### Dependencies

--- a/veracmek/Cargo.toml
+++ b/veracmek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veracmek"
-version = "0.5.15"
+version = "0.5.16"
 edition = "2024"
 description = "CLI tool for managing Customer Managed Encryption Keys (CMEK) on Veracode application profiles"
 authors = ["Veracode API Team"]
@@ -61,5 +61,7 @@ anyhow = "1.0"
 
 # Vault client for secure credential management
 vaultrs = { version = "0.8", features = ["rustls"] }
+rustify = "0.7"
+reqwest = { version = "0.13", features = ["rustls"], default-features = false }
 backon = "1.3"
 url = "2.5"

--- a/veracmek/README.md
+++ b/veracmek/README.md
@@ -2,7 +2,7 @@
 
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-brightgreen.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Crate Version](https://img.shields.io/badge/version-0.5.15-blue.svg)](Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.5.16-blue.svg)](Cargo.toml)
 
 A command-line tool for managing Customer Managed Encryption Keys (CMEK) on Veracode application profiles. This tool enables users to encrypt application data using their own AWS KMS keys, providing enhanced security and compliance for Veracode applications.
 
@@ -57,7 +57,7 @@ veracmek --api-id your_api_id --api-key your_api_key [command]
 ```
 
 #### 3. HashiCorp Vault Integration
-Set the following environment variables to use Vault:
+Set the following environment variables to use Vault. All requests to Vault identify as `veracmek/<version>` via the `User-Agent` header, making Vault audit logs immediately attributable to veracmek.
 
 ```bash
 export VAULT_CLI_ADDR="https://vault.example.com"

--- a/veracmek/src/vault_client.rs
+++ b/veracmek/src/vault_client.rs
@@ -1,6 +1,7 @@
 use crate::credentials::{CredentialError, VaultConfig, validate_api_credential};
 use backon::{ExponentialBuilder, Retryable};
 use log::{debug, error, info, warn};
+use rustify::clients::reqwest::Client as HTTPClient;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
@@ -8,11 +9,14 @@ use std::error::Error;
 use std::time::Duration;
 use url::Url;
 use vaultrs::{
+    api::EndpointMiddleware,
     auth::oidc,
-    client::{Client, VaultClient, VaultClientSettingsBuilder},
+    client::{Client, VaultClient, VaultClientSettings, VaultClientSettingsBuilder},
     error::ClientError,
     kv2, token,
 };
+
+const USER_AGENT: &str = concat!("veracmek/", env!("CARGO_PKG_VERSION"));
 
 // Character sets for validation
 const SPECIAL_CHARS: &[char] = &[
@@ -411,12 +415,51 @@ fn create_vault_client(config: &VaultConfig) -> Result<VaultClient, CredentialEr
             message: format!("Failed to build vault client settings: {e}"),
         })?;
 
-    let client = VaultClient::new(settings).map_err(|e| CredentialError::VaultAuthError {
-        context: format!("Failed to create vault client: {e}"),
-    })?;
+    let client = build_vault_client(settings)?;
 
     debug!("Vault client created successfully");
     Ok(client)
+}
+
+fn build_vault_client(settings: VaultClientSettings) -> Result<VaultClient, CredentialError> {
+    let mut http_builder = reqwest::ClientBuilder::new()
+        .tls_backend_rustls()
+        .user_agent(USER_AGENT);
+
+    http_builder = http_builder.tls_danger_accept_invalid_certs(!settings.verify);
+
+    for path in &settings.ca_certs {
+        let content = std::fs::read(path).map_err(|e| CredentialError::VaultConfigError {
+            message: format!("Failed to read CA cert {path}: {e}"),
+        })?;
+        let certs = reqwest::Certificate::from_pem_bundle(&content).map_err(|e| {
+            CredentialError::VaultConfigError {
+                message: format!("Failed to parse CA cert {path}: {e}"),
+            }
+        })?;
+        http_builder = http_builder.tls_certs_merge(certs);
+    }
+
+    let version_str = format!("v{}", settings.version);
+    let middle = EndpointMiddleware {
+        token: settings.token.clone(),
+        version: version_str,
+        wrap: None,
+        namespace: settings.namespace.clone(),
+    };
+
+    let reqwest_client = http_builder
+        .build()
+        .map_err(|e| CredentialError::VaultConfigError {
+            message: format!("Failed to build HTTP client: {e}"),
+        })?;
+
+    let http = HTTPClient::new(settings.address.as_str(), reqwest_client);
+    Ok(VaultClient {
+        http,
+        middle,
+        settings,
+    })
 }
 
 /// Authenticate with vault using exponential backoff and proper token management

--- a/verascan/CHANGELOG.md
+++ b/verascan/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to verascan will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.6] - 2026-05-30
+
+### Changed
+- **Vault `User-Agent` header**: all HTTP requests to HashiCorp Vault now identify as `verascan/<version>` (e.g. `verascan/0.7.6`), covering authentication, secret retrieval, and token revocation. This makes Vault audit logs and server-side access logs immediately attributable to Verascan without requiring additional configuration
+  - **Modified Files**: `Cargo.toml`, `src/vault_client.rs`
+
 ## [0.7.5] - 2026-05-30
 
 ### Dependencies

--- a/verascan/Cargo.toml
+++ b/verascan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verascan"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2024"
 authors = ["Fred Nollows <frednollows@gmail.com>"]
 description = "A comprehensive Rust client application for the Veracode platform to support pipeline, sandbox and policy scan submission and reporting."
@@ -91,6 +91,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 
 # Vault client for secure credential management
 vaultrs = { version = "0.8", features = ["rustls"] }
+rustify = "0.7"
 backon = "1.3"
 
 [dev-dependencies]

--- a/verascan/README.md
+++ b/verascan/README.md
@@ -2,7 +2,7 @@
 
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-brightgreen.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Crate Version](https://img.shields.io/badge/version-0.7.5-blue.svg)](Cargo.toml)
+[![Crate Version](https://img.shields.io/badge/version-0.7.6-blue.svg)](Cargo.toml)
 
 A comprehensive Rust CLI application for the Veracode platform to support pipeline, sandbox and policy scan submission and reporting.
 
@@ -529,6 +529,7 @@ Verascan supports secure credential management via HashiCorp Vault (inherited fr
 - Smart retry logic following Vault API best practices
 - Fast failure on authentication errors
 - Automatic recovery from transient errors
+- **`User-Agent` header**: all requests to Vault identify as `verascan/<version>`, making Vault audit logs and server-side access logs immediately attributable to Verascan
 
 #### Mid-Scan Credential Refresh
 

--- a/verascan/src/vault_client.rs
+++ b/verascan/src/vault_client.rs
@@ -3,6 +3,7 @@ use crate::credentials::{
 };
 use backon::{ExponentialBuilder, Retryable};
 use log::{debug, error, info, warn};
+use rustify::clients::reqwest::Client as HTTPClient;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
@@ -10,11 +11,14 @@ use std::error::Error;
 use std::time::Duration;
 use url::Url;
 use vaultrs::{
+    api::EndpointMiddleware,
     auth::oidc,
-    client::{Client, VaultClient, VaultClientSettingsBuilder},
+    client::{Client, VaultClient, VaultClientSettings, VaultClientSettingsBuilder},
     error::ClientError,
     kv2, token,
 };
+
+const USER_AGENT: &str = concat!("verascan/", env!("CARGO_PKG_VERSION"));
 
 // Character sets for validation
 const SPECIAL_CHARS: &[char] = &[
@@ -555,12 +559,51 @@ fn create_vault_client(config: &VaultConfig) -> Result<VaultClient, CredentialEr
             message: format!("Failed to build vault client settings: {e}"),
         })?;
 
-    let client = VaultClient::new(settings).map_err(|e| CredentialError::VaultAuthError {
-        context: format!("Failed to create vault client: {e}"),
-    })?;
+    let client = build_vault_client(settings)?;
 
     debug!("Vault client created successfully");
     Ok(client)
+}
+
+fn build_vault_client(settings: VaultClientSettings) -> Result<VaultClient, CredentialError> {
+    let mut http_builder = reqwest::ClientBuilder::new()
+        .tls_backend_rustls()
+        .user_agent(USER_AGENT);
+
+    http_builder = http_builder.tls_danger_accept_invalid_certs(!settings.verify);
+
+    for path in &settings.ca_certs {
+        let content = std::fs::read(path).map_err(|e| CredentialError::VaultConfigError {
+            message: format!("Failed to read CA cert {path}: {e}"),
+        })?;
+        let certs = reqwest::Certificate::from_pem_bundle(&content).map_err(|e| {
+            CredentialError::VaultConfigError {
+                message: format!("Failed to parse CA cert {path}: {e}"),
+            }
+        })?;
+        http_builder = http_builder.tls_certs_merge(certs);
+    }
+
+    let version_str = format!("v{}", settings.version);
+    let middle = EndpointMiddleware {
+        token: settings.token.clone(),
+        version: version_str,
+        wrap: None,
+        namespace: settings.namespace.clone(),
+    };
+
+    let reqwest_client = http_builder
+        .build()
+        .map_err(|e| CredentialError::VaultConfigError {
+            message: format!("Failed to build HTTP client: {e}"),
+        })?;
+
+    let http = HTTPClient::new(settings.address.as_str(), reqwest_client);
+    Ok(VaultClient {
+        http,
+        middle,
+        settings,
+    })
 }
 
 /// Authenticate with vault using exponential backoff and proper token management


### PR DESCRIPTION
## Summary

- All three CLIs (`veraaudit`, `veracmek`, `verascan`) now set a `User-Agent` header on every request to HashiCorp Vault — authentication, secret retrieval, and token revocation
- Header format: `<crate>/<version>` (e.g. `veraaudit/0.6.1`), sourced from `CARGO_PKG_VERSION` at compile time
- Makes Vault audit logs and server-side access logs immediately attributable to the specific CLI without additional configuration

## Version bumps

| Crate | Previous | New |
|-------|----------|-----|
| `veraaudit` | 0.6.0 | 0.6.1 |
| `veracmek` | 0.5.15 | 0.5.16 |
| `verascan` | 0.7.5 | 0.7.6 |

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes
- [ ] Manual smoke test: run any CLI with Vault credentials configured and confirm `veraaudit/0.6.1` (or equivalent) appears in Vault audit log `request.headers.user-agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)